### PR TITLE
add Vulert Vulnerability Scanner

### DIFF
--- a/tools.yaml
+++ b/tools.yaml
@@ -1636,7 +1636,7 @@
   categories:
     - opensource
     - analysis
-- name: Vulert Abom
+- name: Vulert Vulnerability Scanner
   publisher: Vulert.com
   description: Vulert's Abom scanner can monitor and alert you in real-time for open-source vulnerabilities in your software, without requiring access to your code or installation. It uses only an SBOM or manifest file, such as a package-lock.json file. No signup is required.
   websiteUrl: https://vulert.com/abom


### PR DESCRIPTION
It's confusing to have "Abom" on the top of the tool list as there is no such use case "ABOM", this is seems like a marketing trick. Added "Vulert" to make it clear it's a Vulert tool.