### PR TITLE
rename Vulert's Abom -> Vulert Vulnerability Scanner

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -9319,7 +9319,7 @@
       ]
     },
     {
-      "name": "Abom",
+      "name": "Vulert Vulnerability Scanner",
       "publisher": "Vulert.com",
       "description": "Web SCA service that analyzes CycloneDX or SPDX SBOMs (or lockfiles) to flag open-source vulnerabilities and license issues, sending real-time alerts without requiring code access or signup.",
       "website_url": "https://vulert.com/abom",


### PR DESCRIPTION
Due to migration of CycloneDX tool center, this commit was not picked up, and I have received a recommendation to commit again against new repo. Updated tool's name as discussed in the old repo.