### PR TITLE
Update the CycloneDX Web Tool entry to include versions for filter support

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://cyclonedx.org/schema/tool-center-v2.schema.json",
   "specVersion": "2.0",
-  "last_updated": "2025-05-17T10:45:24Z",
+  "last_updated": "2025-07-22T08:05:58Z",
   "license": {
     "id": "CC-BY-SA-4.0",
     "name": "Creative Commons Attribution-ShareAlike 4.0 International",
@@ -2774,7 +2774,15 @@
         "SPDX",
         "PACKAGE_URL"
       ],
-      "cycloneDxVersion": [],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.1",
+        "CYCLONEDX_V1.0"
+      ],
       "supportedLanguages": []
     },
     {


### PR DESCRIPTION
The Web Tool entry had no CycloneDX versions specified. So if anyone had selected a particular CycloneDX spec version it would be excluded from results.