### PR TITLE
feat: split  tools

### DIFF
--- a/.github/workflows/assemble_tools_json.yml
+++ b/.github/workflows/assemble_tools_json.yml
@@ -1,0 +1,96 @@
+name: Assemble tools.json
+
+on:
+  push:
+    branches: [ 'master', 'main' ]
+    paths:
+      - "tools/*"
+      - ".github/workflows/assemble_tools_json.yml"
+  workflow_dispatch:
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  assemble:
+    name: assemble tools.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: assemble tools.json
+        run: helpers/tools-assemble.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tools.json
+          path: tools.json
+
+  validate:
+    needs:
+      - assemble
+    name: validate tools.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+      - name: Download artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: tools.json
+      - name: Validate tools.json
+        run: check-jsonschema --schemafile schemas/tools.schema.json tools.json
+
+  push-back:
+    needs:
+      - assemble
+      - validate
+    name: push tools.json
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # needed for git push
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Download artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: tools.json
+      - name: diff
+        run: git diff tools.json
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Commit tools.json
+        run: |
+          git add tools.json
+          git commit -s -m "Update tools.json [automated commit]" || echo "No changes to commit"
+      - name: git push back
+        run: git push
+
+  publish:
+    needs:
+      - push-back
+    # need to trigger this workflow manually, for the following reason:
+    # The "publish" workflow is triggered whenever a `tools.json` is modified - which happens during
+    # the `push-back` step. and this commit is issued by a bot.
+    # GitHub workflows may triggered on events only if not issues by a bot - so the workflow would
+    # not trigger automatically.
+    uses: .github/workflows/publish_toolcenter.yml

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -3,13 +3,17 @@ name: Build Docs
 on:
   push:
     branches: ['master', 'main']
+    paths:
+      - "schemas/*"
+      - ".github/workflows/build_docs.yml"
   workflow_dispatch:
-
-env:
-  PYTHON_VERSION_DEFAULT: "3.10"
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   docs_json:
@@ -24,8 +28,7 @@ jobs:
       - name: Setup Python Environment
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_DEFAULT }}
-          architecture: 'x64'
+          python-version: 3.x
 
       - name: Generate Schema documentation
         run: ./gen.sh
@@ -45,6 +48,3 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
-        
-      - name: Trigger Cloudflare Deploy Hook
-        run: curl -X POST "${{ secrets.CLOUDFLARE_DEPLOY_HOOK }}"

--- a/.github/workflows/publish_toolcenter.yml
+++ b/.github/workflows/publish_toolcenter.yml
@@ -1,0 +1,23 @@
+name: publish ToolCenter
+
+on:
+  push:
+    branches: [ 'master', 'main' ]
+    paths:
+      - "tools.json"
+      - ".github/workflows/publish_toolcenter.yml"
+  workflow_dispatch:
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trigger_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare Deploy Hook
+        run: curl -X POST "${{ secrets.CLOUDFLARE_DEPLOY_HOOK }}"

--- a/.github/workflows/validate_tools.yml
+++ b/.github/workflows/validate_tools.yml
@@ -1,0 +1,42 @@
+name: Validate each tool
+
+on:
+  push:
+    branches: [ 'master', 'main' ]
+    paths:
+      - "tools/*"
+      - "schemas/tool.schema.json"
+      - ".github/workflows/validate_tools.yml"
+  pull_request:
+    paths:
+      - "tools/*"
+      - "schemas/tool.schema.json"
+      - ".github/workflows/validate_tools.yml"
+  workflow_dispatch:
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: { }
+
+jobs:
+  validate:
+    name: validate each tool
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+
+      - name: Validate all tools
+        run: |
+          set -exu
+          for tool in tools/*.json
+          do
+            check-jsonschema --schemafile schemas/tool.schema.json "$tool"
+          done

--- a/.github/workflows/validate_tools_json.yml
+++ b/.github/workflows/validate_tools_json.yml
@@ -2,20 +2,28 @@ name: Validate tools.json
 
 on:
   push:
-    paths: [ "tools.json", "tools.schema.json", ".github/workflows/validate_tools_json.yml" ]
+    branches: [ 'master', 'main' ]
+    paths:
+      - "tools.json"
+      - "schemas/tools.schema.json"
+      - ".github/workflows/validate_tools_json.yml"
   pull_request:
-    paths: [ "tools.json", "tools.schema.json", ".github/workflows/validate_tools_json.yml" ]
+    branches: [ 'master', 'main' ]
+    paths:
+      - "tools.json"
+      - "schemas/tools.schema.json"
+      - ".github/workflows/validate_tools_json.yml"
   workflow_dispatch:
 
 # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
-permissions: {}
+permissions: { }
 
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -26,4 +34,4 @@ jobs:
         run: pip install check-jsonschema
 
       - name: Validate tools.json
-        run: check-jsonschema --schemafile tools.schema.json tools.json
+        run: check-jsonschema --schemafile schemas/tools.schema.json tools.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 The CycloneDX Tool Center is the largest publicly available collection of SBOM (Software Bill of Materials) and xBOM (e.g., SaaSBOM, CBOM, HBOM) products, projects, and services. It serves as a centralized resource for anyone looking to explore, evaluate, or integrate BOM-related capabilities into their toolchains and workflows. The Tool Center is an integral part of the [CycloneDX website](https://cyclonedx.org).
 
-As of March 2025, the CycloneDX Tool Center leverages a JSON Schema in which `tools.json` must validate against. [View the human-readable documentation for the JSON Schema](https://cyclonedx.github.io/tool-center/).
+As of March 2025, the CycloneDX Tool Center leverages a JSON Schema in which `tools.json` must validate against. [View the human-readable documentation for the JSON Schema](https://cyclonedx.github.io/tool-center/).  
+As of September 2025, the `tools.json` is assembled automatically from the individual JSON files in the `tools/` folder. Do not modify `tools.json` directly, instead add/modify individual files in the `tools/`folder.
 
 ## License
 
@@ -16,8 +17,8 @@ Contributions are welcome! If you know of a tool, product, or service related to
 - Any provided metadata or descriptions are accurate and up-to-date.
 - Licensing and attribution requirements for tools are respected.
 
-Editing the `tools.json` file manually can be complicated. An alternative is to use
-[MetaConfigurator](https://metaconfigurator.github.io/meta-configurator/?schema=https://raw.githubusercontent.com/CycloneDX/tool-center/refs/heads/main/tools.schema.json&data=https://raw.githubusercontent.com/CycloneDX/tool-center/refs/heads/main/tools.json&settings=https://raw.githubusercontent.com/CycloneDX/tool-center/refs/heads/main/metaConfiguratorSettings.json) to make changes then download the edited data.
+Creating/editing a file in the `tools/` folder manually can be complicated. An alternative is to use
+[MetaConfigurator](https://www.metaconfigurator.org?schema=https://raw.githubusercontent.com/CycloneDX/tool-center/refs/heads/main/schemas/tool.schema.json&settings=https://raw.githubusercontent.com/CycloneDX/tool-center/refs/heads/main/metaConfiguratorSettings.json) to make changes then download the edited data.
 
 ## Community & Support
 

--- a/docgen/gen.sh
+++ b/docgen/gen.sh
@@ -6,7 +6,7 @@ DESC="Generate HTML Schema navigator for CycloneDX Tool Center"
 
 # Paths (adjust if needed)
 THIS_PATH="$(realpath "$(dirname "$0")")"
-SCHEMA_PATH="$(realpath "$THIS_PATH/..")"
+SCHEMA_PATH="$(realpath "$THIS_PATH/../schemas")"
 DOCS_PATH="$THIS_PATH/docs"
 TEMPLATES_PATH="$THIS_PATH/templates"
 
@@ -18,18 +18,15 @@ prepare () {
   fi
 }
 
-generate () {
-  local title="CycloneDX Tool Center JSON Reference"
-  echo "Generating: $title"
+clean () {
+  rm -rf "$DOCS_PATH"
+  mkdir -p "$DOCS_PATH"
+}
 
-  local SCHEMA_FILE="$SCHEMA_PATH/tools.schema.json"
-  echo "SCHEMA_FILE: $SCHEMA_FILE"
-
-  local OUT_FILE="$DOCS_PATH/index.html"
-  local OUT_DIR
-  OUT_DIR="$(dirname "$OUT_FILE")"
-  rm -rf "$OUT_DIR"
-  mkdir -p "$OUT_DIR"
+_generate () {
+  local title="$1"
+  local schema_file="$2"
+  local out_file="$3"
 
   # Generate HTML documentation from the JSON schema
   generate-schema-doc \
@@ -40,16 +37,33 @@ generate () {
     --config title="$title" \
     --config custom_template_path="$TEMPLATES_PATH/cyclonedx/base.html" \
     --minify \
-    "$SCHEMA_FILE" \
-    "$OUT_FILE"
+    "$schema_file" \
+    "$out_file"
 
   # Update placeholders in the generated HTML
-  sed -i -e "s/\${quotedTitle}/\"$title\"/g" "$OUT_FILE"
-  sed -i -e "s/\${title}/$title/g" "$OUT_FILE"
+  sed -i -e "s/\${quotedTitle}/\"$title\"/g" "$out_file"
+  sed -i -e "s/\${title}/$title/g" "$out_file"
+}
+
+
+generate_tools () {
+  _generate \
+  "CycloneDX Tool Center v2 - Tools - JSON Reference"\
+  "$SCHEMA_PATH/tools.schema.json" \
+  "$DOCS_PATH/index.html"
+}
+
+generate_tool () {
+  _generate \
+  "CycloneDX Tool Center v2 - Tool - JSON Reference"\
+  "$SCHEMA_PATH/tool.schema.json" \
+  "$DOCS_PATH/tool.html"
 }
 
 # Main
 prepare
-generate
+clean
+generate_tools
+generate_tool
 
 exit 0

--- a/docgen/templates/cyclonedx/base.html
+++ b/docgen/templates/cyclonedx/base.html
@@ -33,6 +33,17 @@
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarScroll" aria-controls="navbarScroll" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
+    <div class="collapse navbar-collapse" id="navbarScroll">
+        <ul class="navbar-nav mr-auto my-2 my-lg-0 navbar-nav-scroll" style="max-height: 100px;">
+            <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarScrollingDropdown" role="button" data-toggle="dropdown" aria-expanded="false">select a schema</a>
+                <ul class="dropdown-menu" aria-labelledby="navbarScrollingDropdown">
+                    <li><a class="dropdown-item" href="index.html">Tools</a></li>
+                    <li><a class="dropdown-item" href="tool.html">Tool</a></li>
+                </ul>
+            </li>
+        </ul>
+    </div>
 </nav>
 
 

--- a/helpers/tools-assemble.py
+++ b/helpers/tools-assemble.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+from datetime import datetime, timezone
+from json import dump as json_dump, load as json_load
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+TOOLS_JSON = REPO_ROOT / 'tools.json'
+TOOLS_FOLDER = REPO_ROOT / 'tools'
+
+tools = []
+
+license_ = {
+    'id': 'CC-BY-SA-4.0',
+    'name': 'Creative Commons Attribution-ShareAlike 4.0 International',
+    'url': 'https://creativecommons.org/licenses/by-sa/4.0/'
+}
+
+now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+for tfn in sorted(TOOLS_FOLDER.glob('*.json')):
+    print('loading', tfn, '...')
+    with open(tfn) as t:
+        tool = json_load(t)
+        tool['tool']['_fromFile'] = tfn.name
+        tools.append(tool['tool'])
+
+print('writing', TOOLS_JSON, '...')
+with open(TOOLS_JSON, 'w') as ts:
+    json_dump({
+        '$schema': 'https://cyclonedx.org/schema/tool-center-v2.schema.json',
+        'specVersion': '2.0',
+        'last_updated': now,
+        'license': license_,
+        'tools': tools
+    }, ts, indent=2)

--- a/helpers/tools-split.py
+++ b/helpers/tools-split.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+from datetime import datetime, timezone
+from json import dump as json_dump, load as json_load
+from pathlib import Path
+from re import compile as re_compile
+
+REPO_ROOT = Path(__file__).parent.parent
+TOOLS_JSON = REPO_ROOT / 'tools.json'
+TOOLS_FOLDER = REPO_ROOT / 'tools'
+
+_tool_fname_replace = re_compile('[^a-zA-Z0-9]+')
+
+
+def make_tool_fname(t):
+    id_ = t.get('id')
+    name = t['name']
+    return f'{id_}.json' if id_ \
+        else f'{_tool_fname_replace.sub("_", name).lower()}.json'
+
+
+with open(TOOLS_JSON) as ts:
+    all_tools = json_load(ts)
+
+spec_version = all_tools['specVersion']
+
+now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+for tool in all_tools['tools']:
+    tfn = make_tool_fname(tool)
+    print('tool', tool['name'], '->', tfn)
+    with open(TOOLS_FOLDER / tfn, 'w') as tf:
+        if '_fromFile' in tool:
+            del tool['_fromFile']
+        if 'repository_url' in tool and tool['repository_url'] is None:
+            del tool['repository_url']
+        if 'website_url' in tool and tool['website_url'] is None:
+            del tool['website_url']
+        json_dump({
+            '$schema': 'https://cyclonedx.org/schema/tool-center-v2.tool.schema.json',
+            'specVersion': spec_version,
+            'tool': tool
+        }, tf, indent=2)

--- a/metaConfiguratorSettings.json
+++ b/metaConfiguratorSettings.json
@@ -1,9 +1,9 @@
 {
-  "settingsVersion": "1.0.2",
+  "settingsVersion": "1.0.3",
   "dataFormat": "json",
-  "toolbarTitle": "MetaConfigurator",
-  "hideSchemaEditor": false,
-  "hideSettings": false,
+  "toolbarTitle": "CycloneDX ToolCenter Editor",
+  "hideSchemaEditor": true,
+  "hideSettings": true,
   "performance": {
     "maxDocumentSizeForValidation": 1024000,
     "maxDocumentSizeForCursorSynchronization": 1240000,
@@ -14,7 +14,7 @@
   "codeEditor": {
     "fontSize": 14,
     "tabSize": 2,
-    "showFormatSelector": true,
+    "showFormatSelector": false,
     "xml": {
       "attributeNamePrefix": "_"
     }
@@ -22,7 +22,9 @@
   "guiEditor": {
     "maximumDepth": 20,
     "propertySorting": "schemaOrder",
-    "hideAddPropertyButton": true
+    "hideAddPropertyButton": true,
+    "showBorderAroundInputFields": true,
+    "showSchemaTitleAsHeader": true
   },
   "schemaDiagram": {
     "editMode": true,
@@ -52,9 +54,14 @@
   "panels": {
     "dataEditor": [
       {
+        "panelType": "textEditor",
+        "mode": "dataEditor",
+        "size": 50
+      },
+      {
         "panelType": "guiEditor",
         "mode": "dataEditor",
-        "size": 40
+        "size": 50
       }
     ],
     "schemaEditor": [
@@ -82,31 +89,11 @@
       }
     ],
     "hidden": [
-      "debug",
       "aiPrompts",
+      "debug",
+      "test",
+      "schemaDiagram",
       "tableView"
     ]
-  },
-  "frontend": {
-    "hostname": "http://metaconfigurator.informatik.uni-stuttgart.de"
-  },
-  "backend": {
-    "hostname": "http://metaconfigurator.informatik.uni-stuttgart.de",
-    "port": 5000
-  },
-  "rdf": {
-    "sparqlEndpointUrl": "https://dbpedia.org/sparql"
-  },
-  "aiIntegration": {
-    "model": "gpt-4o-mini",
-    "maxTokens": 5000,
-    "temperature": 0,
-    "endpoint": "https://api.openai.com/v1/chat/completions"
-  },
-  "openAi": {
-    "model": "gpt-4o-mini",
-    "maxTokens": 5000,
-    "temperature": 0.3,
-    "endpoint": "/chat/completions"
   }
 }

--- a/schemas/tool.schema.json
+++ b/schemas/tool.schema.json
@@ -1,0 +1,371 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "$comment": "CycloneDX Tool Center JSON schema is published under the terms of the Creative Commons Attribution-ShareAlike 4.0 International license.",
+  "title": "CycloneDX Tool Center v2 Tool",
+  "type": "object",
+  "required": [
+    "specVersion",
+    "tool"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference",
+      "examples": [
+        "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json"
+      ]
+    },
+    "$comment": {
+      "type": "string"
+    },
+    "specVersion": {
+      "type": "string",
+      "enum": [
+        "2.0"
+      ],
+      "description": "The version of the Tool Center specification being used. Must be \"2.0\" for this schema."
+    },
+    "tool": {
+      "$ref": "#/definitions/tool",
+      "description": "A list of tool entries describing individual tools and their characteristics. Each entry conforms to the tool object definition."
+    }
+  },
+  "definitions": {
+    "tool": {
+      "type": "object",
+      "required": [
+        "name",
+        "publisher",
+        "description"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The name of the tool."
+        },
+        "publisher": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The individual, organisation, or vendor responsible for publishing or maintaining the tool."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 250,
+          "description": "A short, plain-text description of the tool. Descriptions must not exceed 250 characters."
+        },
+        "repository_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL to the source code repository, if publicly available."
+        },
+        "website_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL to the tool's main website or documentation."
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "AI/ML-BOM",
+              "CBOM",
+              "CDXA",
+              "HBOM",
+              "MBOM",
+              "OBOM",
+              "RELEASE_NOTES",
+              "SAASBOM",
+              "SBOM",
+              "VDR/VEX"
+            ],
+            "meta:enum": {
+              "AI/ML-BOM": "AI/ML Bill of Materials",
+              "CBOM": "Cryptography Bill of Materials",
+              "CDXA": "CycloneDX Attestations",
+              "HBOM": "Hardware Bill of Materials",
+              "MBOM": "Manufacturing Bill of Materials (Formulation)",
+              "OBOM": "Operations Bill of Materials",
+              "RELEASE_NOTES": "Standardized Release Notes Format",
+              "SAASBOM": "Software as-a Service Bill of Materials",
+              "SBOM": "Software Bill of Materials",
+              "VDR/VEX": "Vulnerability Disclosure Report and Vulnerability eXploitability Exchange"
+            }
+          },
+          "description": "Lists the primary capabilities supported by the tool. Refer to [https://cyclonedx.org/capabilities/](https://cyclonedx.org/capabilities) for more information on the capabilities supported by CycloneDX."
+        },
+        "availability": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "COMMERCIAL_LICENSE",
+              "FREEMIUM",
+              "OPEN_SOURCE",
+              "OSI_APPROVED",
+              "SUBSCRIPTION"
+            ],
+            "meta:enum": {
+              "COMMERCIAL_LICENSE": "Requires a proprietary or paid license; not open source and typically restricts redistribution or modification.",
+              "FREEMIUM": "Core features are free to use, with optional paid features or upgrades.",
+              "OPEN_SOURCE": "Freely available under an open-source license.",
+              "OSI_APPROVED": "The tool is licensed under an OSI-approved open-source license.",
+              "SUBSCRIPTION": "Access is provided through a recurring payment model, such as monthly or annually."
+            }
+          },
+          "description": "Indicates the availability or license model."
+        },
+        "functions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ANALYSIS",
+              "AUTHOR",
+              "DISTRIBUTE",
+              "PACKAGE_MANAGER_INTEGRATION",
+              "SIGNING/NOTARY",
+              "TRANSFORM"
+            ],
+            "meta:enum": {
+              "ANALYSIS": "Tools that can analyze CycloneDX BOMs.",
+              "AUTHOR": "Tools that human authors can use to create CycloneDX BOMs.",
+              "DISTRIBUTE": "Tools used to capture and distribute CycloneDX BOMs.",
+              "PACKAGE_MANAGER_INTEGRATION": "Tools that integrate with build systems and package managers.",
+              "SIGNING/NOTARY": "Tools used to sign or notarize software and CycloneDX BOMs.",
+              "TRANSFORM": "Tools that transform CycloneDX into other formats or transform other formats into CycloneDX."
+            }
+          },
+          "description": "Describes what the tool does."
+        },
+        "analysis": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "LICENSE_REPORTING",
+              "OUTDATED_COMPONENTS",
+              "POLICY_EVALUATION",
+              "RESOURCE_REPORTING",
+              "SECURITY_VULNERABILITIES"
+            ],
+            "meta:enum": {
+              "LICENSE_REPORTING": "Extracts and reports license data associated with BOM components to support legal compliance, attribution, and license compatibility analysis. May vary depending on whether components are libraries, containers, or services.",
+              "OUTDATED_COMPONENTS": "Identifies components or services in the BOM that are outdated, deprecated, or no longer supported. This may include checking for newer versions of libraries, services, or platforms.",
+              "POLICY_EVALUATION": "Evaluates BOM contents against defined policies, such as allowed licenses, approved component lists, or internal security/compliance rules. Policies may differ based on BOM type (e.g., stricter rules for embedded systems vs. cloud services).",
+              "RESOURCE_REPORTING": "Analyzes and reports on the resource characteristics of components or services defined in the BOM, such as CPU usage, storage, memory footprint, or cloud infrastructure details.",
+              "SECURITY_VULNERABILITIES": "Performs security vulnerability analysis based on the contents of a BOM. For SBOMs, this typically involves identifying known vulnerabilities in software components (e.g., via CVEs). For SaaSBOMs or other service-inclusive BOMs, the analysis may expand to include service exposure, data handling practices, or configuration weaknesses."
+            }
+          },
+          "description": "Specifies the types of analysis the tool support.s"
+        },
+        "transform": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "BOM_SERIALIZATION_FORMAT",
+              "BOM_STANDARD",
+              "BOM_VERSION"
+            ],
+            "meta:enum": {
+              "BOM_SERIALIZATION_FORMAT": "Transforms the BOM between supported serialization formats such as XML and JSON.",
+              "BOM_STANDARD": "Supports conversion between different BOM standards (e.g., CycloneDX, SPDX).",
+              "BOM_VERSION": "Upgrades or downgrades a BOM to a different version of the same standard."
+            }
+          },
+          "description": "Lists the types of transformations the tool can perform."
+        },
+        "packaging": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "APPLICATION",
+              "AZURE_PIPELINE_EXTENSION",
+              "COMMAND_LINE_UTILITY",
+              "COMPOSER_PLUGIN",
+              "CONAN_EXTENSION",
+              "CONTAINER_IMAGE",
+              "GITHUB_ACTION",
+              "GITHUB_APP",
+              "GITLAB_CI_TEMPLATE",
+              "JENKINS_PLUGIN",
+              "LIBRARY",
+              "MAVEN_PLUGIN",
+              "ROLLUP_PLUGIN",
+              "WEBPACK_PLUGIN",
+              "YARN_PLUGIN"
+            ],
+            "meta:enum": {
+              "AZURE_PIPELINE_EXTENSION": "Extension or task used within Azure DevOps pipelines.",
+              "APPLICATION": "Standalone graphical or web-based application intended for end users.",
+              "COMMAND_LINE_UTILITY": "Tool executed via a command-line interface (CLI), often scriptable and automation-friendly.",
+              "COMPOSER_PLUGIN": "Plugin designed for use within the Composer package manager.",
+              "CONAN_EXTENSION": "Extension designed for use within the Conan package manager.",
+              "CONTAINER_IMAGE": "Packaged as a container image (e.g., Docker), ready for deployment in containerised environments.",
+              "GITHUB_ACTION": "Reusable workflow component that runs as part of GitHub Actions CI/CD pipelines.",
+              "GITHUB_APP": "GitHub-integrated application with extended API access and repository permissions.",
+              "GITLAB_CI_TEMPLATE": "Reusable CI/CD configuration designed for GitLab pipelines.",
+              "JENKINS_PLUGIN": "Plugin or scripted integration compatible with Jenkins pipelines.",
+              "LIBRARY": "Software component intended for integration into other tools or applications via code.",
+              "MAVEN_PLUGIN": "Plugin designed for use within the Maven build system.",
+              "ROLLUP_PLUGIN": "Plugin designed for use within the Rollup build system.",
+              "WEBPACK_PLUGIN": "Plugin designed for use within the webpack build system.",
+              "YARN_PLUGIN": "Plugin designed for use within the yarn package manager."
+            }
+          },
+          "description": "Specifies the distribution or integration format of the tool, reflecting how it is delivered, executed, or embedded within user environments and CI/CD systems."
+        },
+        "library": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "C/C++",
+              "C#",
+              ".NET",
+              "ERLANG_ELIXIR",
+              "FORTRAN",
+              "GO",
+              "GROOVY",
+              "JAVA",
+              "JAVASCRIPT_TYPESCRIPT",
+              "KOTLIN",
+              "NODE.JS",
+              "OCAML",
+              "PERL",
+              "PHP",
+              "PYTHON",
+              "RUBY",
+              "RUST",
+              "SCALA",
+              "SHELL",
+              "SWIFT"
+            ],
+            "description": "Languages or ecosystems in which the tool is implemented or provides libraries."
+          }
+        },
+        "platform": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "LINUX",
+              "MAC",
+              "WINDOWS"
+            ]
+          },
+          "description": "The operating systems the tool supports."
+        },
+        "lifecycle": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "DESIGN",
+              "PRE-BUILD",
+              "BUILD",
+              "POST-BUILD",
+              "OPERATIONS",
+              "DISCOVERY",
+              "DECOMMISSION"
+            ],
+            "meta:enum": {
+              "DESIGN": "BOM produced early in the development lifecycle containing an inventory of components and services that are proposed or planned to be used. The inventory may need to be procured, retrieved, or resourced prior to use.",
+              "PRE-BUILD": "BOM consisting of information obtained prior to a build process and may contain source files and development artifacts and manifests. The inventory may need to be resolved and retrieved prior to use.",
+              "BUILD": "BOM consisting of information obtained during a build process where component inventory is available for use. The precise versions of resolved components are usually available at this time as well as the provenance of where the components were retrieved from.",
+              "POST-BUILD": "BOM consisting of information obtained after a build process has completed and the resulting components(s) are available for further analysis. Built components may exist as the result of a CI/CD process, may have been installed or deployed to a system or device, and may need to be retrieved or extracted from the system or device.",
+              "OPERATIONS": "BOM produced that represents inventory that is running and operational. This may include staging or production environments and will generally encompass multiple SBOMs describing the applications and operating system, along with HBOMs describing the hardware that makes up the system. Operations Bill of Materials (OBOM) can provide full-stack inventory of runtime environments, configurations, and additional dependencies.",
+              "DISCOVERY": "BOM consisting of information observed through network discovery providing point-in-time enumeration of embedded, on-premise, and cloud-native services such as server applications, connected devices, microservices, and serverless functions.",
+              "DECOMMISSION": "BOM containing inventory that will be, or has been retired from operations."
+            },
+            "description": "Specifies the phases of the CycloneDX-defined software lifecycle that the tool supports. This helps indicate when in the software lifecycle the tool is capable of generating, consuming, or modifying CycloneDX artifacts."
+          }
+        },
+        "supportedStandards": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "CPE",
+              "CYCLONEDX",
+              "OMNIBOR",
+              "PACKAGE_URL",
+              "SLSA",
+              "SPDX",
+              "SWID"
+            ],
+            "meta:enum": {
+              "CPE": "Common Platform Enumeration (CPE) – A naming scheme for classifying operating systems, applications, and hardware.",
+              "CYCLONEDX": "CycloneDX – A Bill of Materials (BOM) standard and transparency expression language.",
+              "OMNIBOR": "OmniBOR – A standard for embedding object references to improve traceability and attribution in software artifacts.",
+              "PACKAGE_URL": "Package-URL (PURL) – A standard format for identifying and locating software packages across ecosystems.",
+              "SLSA": "Supply chain Levels for Software Artifacts (SLSA) – A framework for securing software supply chains.",
+              "SPDX": "Software Package Data Exchange (SPDX) – A standard format for communicating software bill of materials (SBOM) information.",
+              "SWID": "Software Identification (SWID) – An XML-based tag format for uniquely identifying software products and their versions."
+            }
+          },
+          "description": "Software supply chain standards that the tool supports."
+        },
+        "cycloneDxVersion": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "CYCLONEDX_V1.6",
+              "CYCLONEDX_V1.5",
+              "CYCLONEDX_V1.4",
+              "CYCLONEDX_V1.3",
+              "CYCLONEDX_V1.2",
+              "CYCLONEDX_V1.1",
+              "CYCLONEDX_V1.0"
+            ],
+            "meta:enum": {
+              "CYCLONEDX_V1.6": "CycloneDX v1.6",
+              "CYCLONEDX_V1.5": "CycloneDX v1.5",
+              "CYCLONEDX_V1.4": "CycloneDX v1.4",
+              "CYCLONEDX_V1.3": "CycloneDX v1.3",
+              "CYCLONEDX_V1.2": "CycloneDX v1.2",
+              "CYCLONEDX_V1.1": "CycloneDX v1.1",
+              "CYCLONEDX_V1.0": "CycloneDX v1.0"
+            }
+          },
+          "description": "Specific versions of the CycloneDX specification that the tool supports."
+        },
+        "supportedLanguages": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "C/C++",
+              ".NET",
+              "ERLANG_ELIXIR",
+              "FORTRAN",
+              "GO",
+              "GROOVY",
+              "JAVA",
+              "JAVASCRIPT/TYPESCRIPT",
+              "KOTLIN",
+              "NIM",
+              "NODE.JS",
+              "PERL",
+              "PHP",
+              "PYTHON",
+              "RUBY",
+              "RUST",
+              "SCALA",
+              "SWIFT"
+            ],
+            "description": "Indicates the programming languages or ecosystems of the artifacts that the tool can analyse, scan, or generate metadata for — not the language the tool itself is written in."
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/tools.schema.json
+++ b/schemas/tools.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://cyclonedx.org/schema/tool-center-v2.schema.json",
-  "$comment" : "CycloneDX Tool Center JSON schema is published under the terms of the Creative Commons Attribution-ShareAlike 4.0 International license.",
-  "title": "CycloneDX Tool Center v2 schema",
+  "$comment": "CycloneDX Tool Center JSON schema is published under the terms of the Creative Commons Attribution-ShareAlike 4.0 International license.",
+  "title": "CycloneDX Tool Center v2",
   "type": "object",
   "required": [
     "specVersion",
@@ -14,7 +14,13 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "format": "uri"
+      "format": "uri-reference",
+      "examples": [
+        "https://cyclonedx.org/schema/tool-center-v2.schema.json"
+      ]
+    },
+    "$comment": {
+      "type": "string"
     },
     "specVersion": {
       "type": "string",
@@ -55,7 +61,9 @@
     },
     "tools": {
       "type": "array",
-      "items": {"$ref": "#/definitions/tool"},
+      "items": {
+        "$ref": "#/definitions/tool"
+      },
       "uniqueItems": true,
       "description": "A list of tool entries describing individual tools and their characteristics. Each entry conforms to the tool object definition."
     }
@@ -87,12 +95,12 @@
           "description": "A short, plain-text description of the tool. Descriptions must not exceed 250 characters."
         },
         "repository_url": {
-          "type": ["string", "null"],
+          "type": "string",
           "format": "uri",
           "description": "The URL to the source code repository, if publicly available."
         },
         "website_url": {
-          "type": ["string", "null"],
+          "type": "string",
           "format": "uri",
           "description": "The URL to the tool's main website or documentation."
         },
@@ -392,6 +400,11 @@
             ],
             "description": "Indicates the programming languages or ecosystems of the artifacts that the tool can analyse, scan, or generate metadata for — not the language the tool itself is written in."
           }
+        },
+        "_fromFile": {
+          "type": "string",
+          "minLength": 1,
+          "description": "from which file was the tool taken?"
         }
       }
     }

--- a/tools.json
+++ b/tools.json
@@ -1,6783 +1,13 @@
 {
   "$schema": "https://cyclonedx.org/schema/tool-center-v2.schema.json",
   "specVersion": "2.0",
-  "last_updated": "2025-07-22T08:05:58Z",
+  "last_updated": "2025-09-10T13:40:27Z",
   "license": {
     "id": "CC-BY-SA-4.0",
     "name": "Creative Commons Attribution-ShareAlike 4.0 International",
     "url": "https://creativecommons.org/licenses/by-sa/4.0/"
   },
   "tools": [
-    {
-      "name": "CycloneDX Core for Java",
-      "publisher": "OWASP Foundation (CycloneDX Project)",
-      "description": "Java library for creating, parsing, and validating CycloneDX SBOMs.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-core-java",
-      "website_url": "https://cyclonedx.github.io/cyclonedx-core-java/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "JAVA"
-      ]
-    },
-    {
-      "name": "CycloneDX for .NET",
-      "publisher": "CycloneDX",
-      "description": "Generates CycloneDX Software Bill of Materials (SBOM) from .NET projects.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-dotnet",
-      "website_url": "https://www.nuget.org/packages/CycloneDX/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        ".NET"
-      ]
-    },
-    {
-      "name": "CycloneDX Libraries for .NET",
-      "publisher": "CycloneDX",
-      "description": ".NET libraries to consume and produce CycloneDX Software Bill of Materials (SBOM).",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-dotnet-library",
-      "website_url": "https://www.nuget.org/profiles/CycloneDX",
-      "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "OBOM",
-        "MBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        ".NET"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DESIGN",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "SWID"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        ".NET"
-      ]
-    },
-    {
-      "name": "CycloneDX JavaScript Library",
-      "publisher": "CycloneDX",
-      "description": "Core functionality of CycloneDX for JavaScript (Node.js or Web Browser) written in TypeScript.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-javascript-library",
-      "website_url": "https://www.npmjs.com/package/@cyclonedx/cyclonedx-library",
-      "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "OBOM",
-        "MBOM",
-        "HBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT",
-        "NODE.JS"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "SWID"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS"
-      ]
-    },
-    {
-      "name": "CycloneDX for Node.js",
-      "publisher": "OWASP Foundation (CycloneDX Project)",
-      "description": "This is a so-called meta-package, it does not ship any own functionality, but it is a collection of optional dependencies with one purpose in common: generate CycloneDX Software-Bill-of-Materials (SBOM) from node-based projects.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-node-module",
-      "website_url": "https://www.npmjs.com/package/@cyclonedx/bom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "NODE.JS"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS"
-      ]
-    },
-    {
-      "name": "CycloneDX for NPM",
-      "publisher": "CycloneDX",
-      "description": "Create CycloneDX Software Bill of Materials (SBOM) from npm projects.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-node-npm",
-      "website_url": "https://www.npmjs.com/package/@cyclonedx/cyclonedx-npm",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT",
-        "NODE.JS"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DESIGN",
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ]
-    },
-    {
-      "name": "CycloneDX for Yarn",
-      "publisher": "CycloneDX",
-      "description": "Create CycloneDX Software Bill of Materials (SBOM) from yarn projects.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-node-yarn",
-      "website_url": "https://classic.yarnpkg.com/en/package/@cyclonedx/yarn-plugin-cyclonedx",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "YARN_PLUGIN",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT",
-        "NODE.JS"
-      ],
-      "supportedLanguages": [
-        "NODE.JS",
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "CycloneDX for Webpack",
-      "publisher": "OWASP Foundation",
-      "description": "Webpack plugin that generates CycloneDX Software Bill of Materials (SBOM) for JavaScript/TypeScript bundles during the build process.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin",
-      "website_url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "WEBPACK_PLUGIN"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT",
-        "NODE.JS"
-      ]
-    },
-    {
-      "name": "CycloneDX for Maven",
-      "publisher": "OWASP Foundation / CycloneDX Project",
-      "description": "Apache Maven plugin that automatically generates CycloneDX SBOMs (JSON or XML) for Java projects and can attach vulnerability disclosure information.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-maven-plugin",
-      "website_url": "https://github.com/CycloneDX/cyclonedx-maven-plugin",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "CPE"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "JAVA"
-      ]
-    },
-    {
-      "name": "CycloneDX library for Go",
-      "publisher": "CycloneDX",
-      "description": "Go library that can parse, create and serialize CycloneDX Software Bill of Materials (SBOM) in JSON or XML.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-go",
-      "website_url": "https://github.com/CycloneDX/cyclonedx-go",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DESIGN",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "CycloneDX for Go modules",
-      "publisher": "OWASP Foundation – CycloneDX Project",
-      "description": "Command-line utility and Go library that generates CycloneDX SBOMs from Go modules, binaries and applications.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-gomod",
-      "website_url": "https://github.com/CycloneDX/cyclonedx-gomod",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "CycloneDX for Gradle",
-      "publisher": "CycloneDX",
-      "description": "Gradle plugin that generates CycloneDX SBOMs (XML or JSON) for all dependencies in Java-based builds.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-gradle-plugin",
-      "website_url": "https://plugins.gradle.org/plugin/org.cyclonedx.bom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "JAVA"
-      ]
-    },
-    {
-      "name": "CycloneDX for PHP Composer",
-      "publisher": "CycloneDX",
-      "description": "Create CycloneDX Software Bill of Materials (SBOM) from PHP Composer projects.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-php-composer",
-      "website_url": "https://packagist.org/packages/cyclonedx/cyclonedx-php-composer",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMPOSER_PLUGIN",
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.1"
-      ],
-      "library": [
-        "PHP"
-      ],
-      "supportedLanguages": [
-        "PHP"
-      ]
-    },
-    {
-      "name": "CycloneDX PHP Library",
-      "publisher": "CycloneDX",
-      "description": "PHP library that supplies data-models, serializers, validators and utilities for creating, parsing and validating CycloneDX BOM documents in JSON and XML formats.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-php-library",
-      "website_url": "https://packagist.org/packages/cyclonedx/cyclonedx-library",
-      "capabilities": [
-        "SBOM",
-        "HBOM",
-        "OBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "PHP"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.1"
-      ],
-      "supportedLanguages": [
-        "PHP"
-      ]
-    },
-    {
-      "name": "CycloneDX for Python",
-      "publisher": "CycloneDX",
-      "description": "Generates CycloneDX SBOMs from Python (virtual) environments, requirement files, and manifests (Poetry, PipEnv, etc)",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-python",
-      "website_url": "https://pypi.org/project/cyclonedx-bom/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.1",
-        "CYCLONEDX_V1.0"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "CycloneDX Python Library",
-      "publisher": "CycloneDX",
-      "description": "This Python package provides data models, validators and more, to help you create/render/read CycloneDX documents.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-python-lib",
-      "website_url": "https://pypi.org/project/cyclonedx-python-lib/",
-      "capabilities": [
-        "SBOM",
-        "CBOM",
-        "MBOM",
-        "OBOM",
-        "SAASBOM",
-        "RELEASE_NOTES",
-        "VDR/VEX",
-        "CDXA",
-        "HBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "SWID"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.1",
-        "CYCLONEDX_V1.0"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "CycloneDX for Ruby Gems",
-      "publisher": "OWASP Foundation",
-      "description": "Command-line utility and Ruby library that generates CycloneDX SBOMs for Ruby projects by analysing Gem dependencies.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-ruby-gem",
-      "website_url": "https://rubygems.org/gems/cyclonedx-ruby",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "RUBY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "RUBY"
-      ]
-    },
-    {
-      "name": "CycloneDX for Rust Cargo",
-      "publisher": "CycloneDX Project (OWASP)",
-      "description": "Cargo sub-command and CLI library that generates CycloneDX SBOMs for Rust projects, aggregating all crate dependencies and outputting JSON or XML.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-rust-cargo",
-      "website_url": "https://crates.io/crates/cyclonedx-bom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "RUST"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "RUST"
-      ]
-    },
-    {
-      "name": "CycloneDX for SBT (Scala)",
-      "publisher": "Fabrizio Di Giuseppe",
-      "description": "SBT plugin that generates CycloneDX SBOMs (JSON or XML) for Scala/Java builds, supporting schema v1.6 and integrating smoothly with Dependency-Track.",
-      "repository_url": "https://github.com/sbt/sbt-sbom",
-      "website_url": "https://github.com/sbt/sbt-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "SCALA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "SCALA"
-      ]
-    },
-    {
-      "name": "CycloneDX for Erlang/Elixir (Mix)",
-      "publisher": "Bram Verburg",
-      "description": "Mix task that generates CycloneDX SBOMs for Erlang/Elixir projects, exporting XML or JSON and supporting multiple CycloneDX schema versions.",
-      "repository_url": "https://github.com/voltone/sbom",
-      "website_url": "https://hex.pm/packages/sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "ERLANG_ELIXIR"
-      ],
-      "library": [
-        "ERLANG_ELIXIR"
-      ]
-    },
-    {
-      "name": "CycloneDX for Erlang/Elixir (Rebar3)",
-      "publisher": "Bram Verburg",
-      "description": "Rebar3 plug-in that generates CycloneDX SBOMs for Erlang/Elixir projects, exporting XML or JSON and supporting CycloneDX v1.4.",
-      "repository_url": "https://github.com/voltone/rebar3_sbom",
-      "website_url": "https://hex.pm/packages/rebar3_sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "ERLANG_ELIXIR"
-      ],
-      "library": [
-        "ERLANG_ELIXIR"
-      ]
-    },
-    {
-      "name": "CycloneDX for Go",
-      "publisher": "Ozon",
-      "description": "Command-line utility and Go library that generates CycloneDX SBOMs from Go module projects for supply-chain transparency.",
-      "repository_url": "https://github.com/ozonru/cyclonedx-go",
-      "website_url": "https://github.com/ozonru/cyclonedx-go",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "CycloneDX for Bower",
-      "publisher": "Hans Thorhauge Dam",
-      "description": "Creates CycloneDX Software Bill of Materials (SBOM) from JavaScript projects that manage dependencies with Bower.",
-      "repository_url": "https://github.com/hanstdam/cdx-bower-bom",
-      "website_url": "https://www.npmjs.com/package/cdx-bower-bom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "cdxgen",
-      "publisher": "CycloneDX",
-      "description": "Universal polyglot CLI, library and server that generates CycloneDX SBOMs—including SaaSBOM, OBOM and CBOM variants—for source code, container images and cloud resources.",
-      "repository_url": "https://github.com/CycloneDX/cdxgen",
-      "website_url": "https://cyclonedx.github.io/cdxgen/",
-      "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "CBOM",
-        "OBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "SIGNING/NOTARY"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT",
-        "NODE.JS"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "CycloneDX-Buildroot",
-      "publisher": "CycloneDX",
-      "description": "Python application that generates CycloneDX Software Bill of Materials (SBOM) for Buildroot-generated projects and other projects with CSV manifest files",
-      "repository_url": "https://github.com/cyclonedx/cyclonedx-buildroot",
-      "website_url": "https://pypi.org/project/cyclonedx-buildroot/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++"
-      ]
-    },
-    {
-      "name": "Eclipse SW360 Antenna",
-      "publisher": "Eclipse Foundation",
-      "description": "Archived tool that scanned project artifacts, downloaded sources for dependencies, validated licenses, and generated license compliance documentation",
-      "repository_url": "https://github.com/eclipse-archived/antenna",
-      "website_url": "https://www.eclipse.org/sw360/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING",
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVA"
-      ]
-    },
-    {
-      "name": "CycloneDX Node.js Generate SBOM",
-      "publisher": "CycloneDX",
-      "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for Node.js projects containing an aggregate of all project dependencies. (note: considered deprecated)",
-      "repository_url": "https://github.com/CycloneDX/gh-node-module-generatebom",
-      "website_url": "https://github.com/marketplace/actions/cyclonedx-node-js-generate-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "NODE.JS",
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "CycloneDX .NET Generate SBOM",
-      "publisher": "CycloneDX",
-      "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for .NET projects supporting multiple project formats and recursive analysis",
-      "repository_url": "https://github.com/CycloneDX/gh-dotnet-generate-sbom",
-      "website_url": "https://github.com/marketplace/actions/cyclonedx-dotnet-generate-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        ".NET"
-      ]
-    },
-    {
-      "name": "CycloneDX PHP Composer Generate SBOM",
-      "publisher": "CycloneDX",
-      "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for PHP Composer projects (note: considered deprecated)",
-      "repository_url": "https://github.com/CycloneDX/gh-php-composer-generate-sbom",
-      "website_url": "https://github.com/marketplace/actions/cyclonedx-php-composer-generate-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "PHP"
-      ]
-    },
-    {
-      "name": "CycloneDX Python Generate SBOM",
-      "publisher": "CycloneDX",
-      "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for Python projects from requirements files (note: considered deprecated)",
-      "repository_url": "https://github.com/CycloneDX/gh-python-generate-sbom",
-      "website_url": "https://github.com/marketplace/actions/cyclonedx-python-generate-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "Generate SBoM for Elixir project",
-      "publisher": "Red Shirts",
-      "description": "GitHub Action to generate CycloneDX Software Bill-of-Materials (SBOM) for Erlang/Elixir Mix projects",
-      "repository_url": "https://github.com/red-shirts/action-mix-sbom",
-      "website_url": "https://github.com/marketplace/actions/generate-sbom-for-elixir-project",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [],
-      "transform": [],
-      "packaging": [
-        "GITHUB_ACTION",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "ERLANG_ELIXIR"
-      ]
-    },
-    {
-      "name": "OSS Review Toolkit (ORT)",
-      "publisher": "OSS Review Toolkit",
-      "description": "A comprehensive suite of tools to automate software compliance checks, analyze dependencies / vulnerabilities, and generate reports.",
-      "repository_url": "https://github.com/oss-review-toolkit/ort",
-      "website_url": "https://oss-review-toolkit.org/",
-      "capabilities": [
-        "SBOM",
-        "CBOM",
-        "OBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "LIBRARY",
-        "APPLICATION",
-        "GITHUB_ACTION",
-        "GITLAB_CI_TEMPLATE",
-        "JENKINS_PLUGIN"
-      ],
-      "library": [
-        "JAVA",
-        "KOTLIN"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "CPE",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.1",
-        "CYCLONEDX_V1.0"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        ".NET",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "KOTLIN",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SCALA",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "Retire.js",
-      "publisher": "RetireJS",
-      "description": "Scanner that detects the use of JavaScript libraries with known vulnerabilities in web and Node.js applications and can generate CycloneDX-format SBOMs.",
-      "repository_url": "https://github.com/RetireJS/retire.js",
-      "website_url": "https://retirejs.github.io/retire.js",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT",
-        "NODE.JS"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS"
-      ]
-    },
-    {
-      "name": "Dependency-Track",
-      "publisher": "OWASP",
-      "description": "An intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain by leveraging SBOMs",
-      "repository_url": "https://github.com/DependencyTrack/dependency-track",
-      "website_url": "https://dependencytrack.org/",
-      "capabilities": [
-        "HBOM",
-        "OBOM",
-        "SAASBOM",
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "CONTAINER_IMAGE",
-        "APPLICATION"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "CPE",
-        "SWID"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "RUBY",
-        "PHP",
-        "RUST",
-        "C/C++",
-        ".NET",
-        "PERL",
-        "ERLANG_ELIXIR"
-      ]
-    },
-    {
-      "name": "Dependency-Track Jenkins Plugin",
-      "publisher": "OWASP",
-      "description": "Jenkins plugin that publishes CycloneDX Software Bill-of-Materials (SBOM) to the Dependency-Track platform for vulnerability analysis and policy evaluation",
-      "repository_url": "https://github.com/jenkinsci/dependency-track-plugin",
-      "website_url": "https://plugins.jenkins.io/dependency-track/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "JENKINS_PLUGIN"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Dependency-Track Maven Plugin",
-      "publisher": "Paul McKeown",
-      "description": "Maven plugin that integrates with a Dependency-Track server to submit SBOMs and optionally fail execution when vulnerable dependencies are found",
-      "repository_url": "https://github.com/pmckeown/dependency-track-maven-plugin",
-      "website_url": "https://github.com/pmckeown/dependency-track-maven-plugin#readme",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "MAVEN_PLUGIN"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVA"
-      ]
-    },
-    {
-      "name": "dtrack-audit",
-      "publisher": "OZON",
-      "description": "Command-line client for OWASP Dependency-Track that publishes SBOMs and displays vulnerability information from the command line, designed for CI/CD integration",
-      "repository_url": "https://github.com/ozontech/dtrack-audit",
-      "website_url": "https://github.com/ozontech/dtrack-audit",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "ShiftLeft Scan",
-      "publisher": "ShiftLeft",
-      "description": "A free open-source security tool for modern DevOps teams that performs static analysis-based security testing across multiple languages and frameworks",
-      "repository_url": "https://github.com/ShiftLeftSecurity/sast-scan",
-      "website_url": "https://www.shiftleft.io/scan/",
-      "capabilities": [],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "PACKAGE_URL"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "SCANOSS",
-      "publisher": "SCANOSS",
-      "description": "Open source software identification and inventory tool that provides insights into license compliance, security vulnerabilities, and software composition analysis",
-      "repository_url": "https://github.com/scanoss/engine",
-      "website_url": "https://www.scanoss.com/",
-      "capabilities": [],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "oss_inventory",
-      "publisher": "Thiago Pinto",
-      "description": "A tool to import CycloneDX BOMs and visualize open source software statistics for dependency analysis and reporting",
-      "repository_url": "https://github.com/thspinto/oss_inventory",
-      "website_url": "https://github.com/thspinto/oss_inventory",
-      "capabilities": [],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Auditjs",
-      "publisher": "Sonatype",
-      "description": "Audits JavaScript projects to identify known vulnerabilities and outdated package versions using the OSS Index v3 REST API",
-      "repository_url": "https://github.com/sonatype-nexus-community/auditjs",
-      "website_url": "https://github.com/sonatype-nexus-community/auditjs",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "Chelsea",
-      "publisher": "Sonatype",
-      "description": "Dependency vulnerability auditor for Ruby",
-      "repository_url": "https://github.com/sonatype-nexus-community/chelsea",
-      "website_url": "https://github.com/sonatype-nexus-community/chelsea",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "RUBY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "RUBY"
-      ]
-    },
-    {
-      "name": "Jake",
-      "publisher": "Sonatype",
-      "description": "An OSS Index integration to check your Conda environments for vulnerable Open Source packages",
-      "repository_url": "https://github.com/sonatype-nexus-community/jake",
-      "website_url": "https://jake.readthedocs.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "Nancy",
-      "publisher": "Sonatype",
-      "description": "A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index",
-      "repository_url": "https://github.com/sonatype-nexus-community/nancy",
-      "website_url": "https://github.com/sonatype-nexus-community/nancy",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "Go Sonatypes",
-      "publisher": "Sonatype",
-      "description": "Common utility packages for working with OSS Index, Nexus IQ Server, CycloneDX SBOMs or getting a user-agent",
-      "repository_url": "https://github.com/sonatype-nexus-community/go-sona-types",
-      "website_url": "https://github.com/sonatype-nexus-community/go-sona-types",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "Valaa Stack",
-      "publisher": "Valaa Technologies",
-      "description": "SBoMDoc is a VDoc extension which uses CycloneDX namespaces and can emit BOM documents in various formats",
-      "repository_url": "https://github.com/valaatech/kernel",
-      "website_url": "https://valospace.org/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "TRANSFORM"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "Nexus IQ",
-      "publisher": "Sonatype",
-      "description": "Software Composition Analysis (SCA) platform that can consume, analyze, and produce CycloneDX SBOMs",
-      "website_url": "https://www.sonatype.com/product-nexus-lifecycle",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "Nexus Lifecycle Jenkins Plugin",
-      "publisher": "Sonatype",
-      "description": "Publishes CycloneDX SBOMs to Nexus IQ for per-build analysis, result visualization, and policy evaluation",
-      "repository_url": "https://github.com/jenkinsci/nexus-platform-plugin",
-      "website_url": "https://help.sonatype.com/en/sonatype-platform-plugin-for-jenkins.html",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "JENKINS_PLUGIN"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PERL",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "MedScan",
-      "publisher": "MedSec",
-      "description": "Consumes SBOMs to help hospitals manage medical device assets, providing vulnerability and resource analysis for compliance and risk management.",
-      "repository_url": "https://www.medsec.com/",
-      "website_url": "https://www.medsec.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "RESOURCE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Reliza Hub",
-      "publisher": "Reliza",
-      "description": "Publishes and ingests SBOMs for metadata management, compliance, and distribution. Supports CycloneDX and SPDX standards for software supply chain transparency.",
-      "repository_url": "https://relizahub.com/",
-      "website_url": "https://relizahub.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "DISTRIBUTE",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "RESOURCE_REPORTING",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "WINDOWS",
-        "MAC"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "SwiftBOM",
-      "publisher": "CERT Coordination Center (CERT/CC)",
-      "description": "Generates SBOMs for demo and PoC purposes. Supports output in CycloneDX, SPDX, and SWID formats. Visualizes SBOMs as tree graphs.",
-      "repository_url": "https://github.com/CERTCC/SBOM",
-      "website_url": "https://sbom.democert.org/sbom/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SWID"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "DtrackAuditor",
-      "publisher": "Thinksabin",
-      "description": "Python CLI tool to upload CycloneDX SBOMs to Dependency-Track, analyze vulnerabilities, enforce policy, and fail CI builds based on thresholds.",
-      "repository_url": "https://github.com/thinksabin/DTrackAuditor",
-      "website_url": "https://github.com/thinksabin/DTrackAuditor",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "Syft",
-      "publisher": "Anchore",
-      "description": "CLI tool and library for generating a Software Bill of Materials from container images and filesystems.",
-      "repository_url": "https://github.com/anchore/syft",
-      "website_url": "https://anchore.github.io/syft/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "RESOURCE_REPORTING",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_STANDARD",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "Grype",
-      "publisher": "Anchore",
-      "description": "A vulnerability scanner for container images and filesystems. Works with Syft SBOMs and supports CycloneDX, SPDX, and OpenVEX.",
-      "repository_url": "https://github.com/anchore/grype",
-      "website_url": "https://github.com/anchore/grype",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC"
-      ],
-      "lifecycle": [
-        "DISCOVERY",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL",
-        "CPE"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "CycloneDX CLI",
-      "publisher": "CycloneDX",
-      "description": "CLI tool for SBOM analysis, merging, diffs, format conversions, signing, and validation. Supports CycloneDX XML/JSON/Protobuf/CSV, SPDX JSON, and more.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-cli",
-      "website_url": "https://cyclonedx.org/",
-      "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "OBOM",
-        "MBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "TRANSFORM",
-        "SIGNING/NOTARY"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        ".NET"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "CycloneDX Web Tool",
-      "publisher": "CycloneDX",
-      "description": "Web-based tool for validating, viewing, and converting CycloneDX SBOMs. Supports XML/JSON, and conversion between CycloneDX and SPDX formats.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-web-tool",
-      "website_url": "https://cyclonedx.github.io/cyclonedx-web-tool/",
-      "capabilities": [
-        "SBOM",
-        "OBOM",
-        "MBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.1",
-        "CYCLONEDX_V1.0"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "CycloneDX Rust",
-      "publisher": "Mark Dodgson",
-      "description": "Simple Rust library to encode and decode CycloneDX BOMs.",
-      "repository_url": "https://github.com/doddi/cyclonedx-rust",
-      "website_url": "https://github.com/doddi/cyclonedx-rust",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "RUST"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "CycloneDX for Cocoapods",
-      "publisher": "CycloneDX",
-      "description": "Creates CycloneDX SBOMs for Objective-C and Swift projects that use CocoaPods.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-cocoapods",
-      "website_url": "https://github.com/CycloneDX/cyclonedx-cocoapods",
-      "capabilities": [
-        "SBOM",
-        "OBOM",
-        "MBOM",
-        "SAASBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "RUBY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "mdbom",
-      "publisher": "Robert Hansel",
-      "description": "A simple command line tool to transform CycloneDX SBoMs to markdown.",
-      "repository_url": "https://github.com/HaRo87/mdbom",
-      "website_url": "https://haro87.github.io/mdbom/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "TRANSFORM"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "PYTHON",
-        "JAVASCRIPT/TYPESCRIPT",
-        "GO"
-      ]
-    },
-    {
-      "name": "OpenRewrite",
-      "publisher": "OpenRewrite Project",
-      "description": "Open-source automated refactoring ecosystem for code transformation, security remediation, and dependency management through reusable recipes and build tool plugins.",
-      "repository_url": "https://github.com/openrewrite/rewrite",
-      "website_url": "https://docs.openrewrite.org/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "RESOURCE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "LIBRARY",
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY",
-        "MAVEN_PLUGIN"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVA",
-        "KOTLIN",
-        "GROOVY",
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "Defect Dojo",
-      "publisher": "OWASP",
-      "description": "Open source vulnerability management and automation platform that can import CycloneDX SBOMs and over 190 security tool reports for centralized vulnerability tracking and analysis.",
-      "repository_url": "https://github.com/DefectDojo/django-DefectDojo",
-      "website_url": "https://www.defectdojo.org/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PERL",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "OSS Inventory",
-      "publisher": "Thiago Pinto",
-      "description": "A web application for importing, storing, and visualizing CycloneDX SBOMs, allowing organizations to track software components across projects.",
-      "repository_url": "https://github.com/thspinto/oss_inventory",
-      "website_url": "https://github.com/thspinto/oss_inventory",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "RESOURCE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Fortress File Integrity Assurance",
-      "publisher": "Fortress Information Security",
-      "description": "A proprietary software analysis tool that validates patches and ensures software file integrity to enhance software supply chain security in critical infrastructure environments.",
-      "website_url": "https://www.fortressinfosec.com/",
-      "repository_url": "https://www.fortressinfosec.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Fortress Asset 2 Vendor",
-      "publisher": "Fortress Information Security",
-      "description": "Comprehensive cyber supply chain risk management platform that ingests, analyzes and securely shares SBOMs, HBOMs and other supply chain attestations via SaaS and permissioned blockchain.",
-      "website_url": "https://assettovendor.com/",
-      "repository_url": "https://assettovendor.com",
-      "capabilities": [
-        "SBOM",
-        "HBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "DISTRIBUTE",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Software Assurance Guardian Point Man",
-      "publisher": "Reliable Energy Analytics LLC",
-      "description": "A patented tool that performs comprehensive software supply chain risk assessments using a 7-step process to detect vulnerabilities and calculate trustworthiness scores for software.",
-      "website_url": "https://reliableenergyanalytics.com/products",
-      "repository_url": "https://reliableenergyanalytics.com/products",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Cybeats SBOM Studio",
-      "publisher": "Cybeats Technologies Inc.",
-      "description": "Enterprise solution to manage SBOMs at scale and proactively discover and reduce risk across the entire software supply chain, from development through deployment.",
-      "repository_url": "https://github.com/cybeats",
-      "website_url": "https://www.cybeats.com/product/sbom-studio",
-      "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "TRANSFORM",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "RESOURCE_REPORTING",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "TrustSource",
-      "publisher": "TrustSource",
-      "description": "SaaS platform for implementing and maintaining open source compliance that imports CycloneDX SBOMs, analyzes them for licenses and vulnerabilities, and integrates with various development workflows.",
-      "repository_url": "https://github.com/trustsource",
-      "website_url": "https://www.trustsource.io/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "TRANSFORM",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION",
-        "RESOURCE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT",
-        "PYTHON",
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PYTHON",
-        "RUBY"
-      ]
-    },
-    {
-      "name": "JDisc Discovery",
-      "publisher": "JDisc",
-      "description": "Network discovery and IT inventory tool that can discover CycloneDX SBOMs on enterprise assets and ingest component inventory into the platform.",
-      "website_url": "https://www.jdisc.com/",
-      "repository_url": "https://www.jdisc.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DISCOVERY",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "PulseUno Plugin for Dimensions CM",
-      "publisher": "Micro Focus",
-      "description": "PulseUno enables development teams to continually build and inspect the health and quality of code using plugins such as CycloneDX. Teams can use this information for merge, deployment, and release decisions.",
-      "repository_url": "https://www.microfocus.com/en-us/products/dimensions-cm",
-      "website_url": "https://www.microfocus.com/en-us/products/dimensions-cm",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "PACKAGE_MANAGER_INTEGRATION",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "CycloneDX GoMod Generate SBOM",
-      "publisher": "CycloneDX",
-      "description": "GitHub action which generates CycloneDX SBOMs from Go modules, providing integration into CI/CD workflows for Go projects.",
-      "repository_url": "https://github.com/CycloneDX/gh-gomod-generate-sbom",
-      "website_url": "https://github.com/marketplace/actions/cyclonedx-gomod-generate-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "BOM Repository Server",
-      "publisher": "CycloneDX",
-      "description": "A lightweight repository server used to publish, manage, and distribute CycloneDX SBOMs.",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-bom-repo-server",
-      "website_url": "https://github.com/CycloneDX/cyclonedx-bom-repo-server",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "DISTRIBUTE"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "CONTAINER_IMAGE"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ]
-    },
-    {
-      "name": "ittosai",
-      "publisher": "DevOps KungFu Masters",
-      "description": "ittosai is a CycloneDX SBOM vulnerability analyzer that analyzes SBOMs every time a developer commits code to a repository.",
-      "repository_url": "https://github.com/devops-kung-fu/ittosai",
-      "website_url": "https://dkfm.io/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "CodeSentry",
-      "publisher": "GrammaTech",
-      "description": "Software Composition Analysis (SCA) platform that leverages binary analysis to identify components, inherited risk, and communicates inventory through CycloneDX SBOMs",
-      "website_url": "https://www.grammatech.com",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "Heimdall",
-      "publisher": "MedCrypt",
-      "description": "Automatically extract or manually upload your Software Bill of Materials (SBOM), and Heimdall will, on a continual basis, identify known vulnerabilities affecting your software components",
-      "website_url": "https://www.medcrypt.com/solutions/helm",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "Contrast Security",
-      "publisher": "Contrast Security",
-      "description": "Automatically generates component inventory from runtime analysis (IAST or RASP) and generates CycloneDX SBOMs",
-      "website_url": "https://www.contrastsecurity.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "LIBRARY",
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS",
-        ".NET",
-        "PYTHON",
-        "GO",
-        "PHP",
-        "RUBY"
-      ]
-    },
-    {
-      "name": "Salus",
-      "publisher": "Coinbase",
-      "description": "Salus is a tool for coordinating the execution of security scanners. Salus can generate CycloneDX SBOMs from many language ecosystems.",
-      "repository_url": "https://github.com/coinbase/salus",
-      "website_url": "https://github.com/coinbase/salus",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "supportedLanguages": [
-        "RUBY",
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS",
-        "PYTHON",
-        "GO",
-        "RUST"
-      ]
-    },
-    {
-      "name": "Codenotary vcn",
-      "publisher": "Codenotary",
-      "description": "Protects an organization's software development pipeline from supply chain attacks. Codenotary natively supports CycloneDX SBOMs.",
-      "repository_url": "https://github.com/codenotary/vcn",
-      "website_url": "https://codenotary.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "SIGNING/NOTARY"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "CodeNotary CAS",
-      "publisher": "CodeNotary",
-      "description": "CAS is an open source attestation service for the community. Notarize and authorize files, directories, git repos and Build SBOMs of containers.",
-      "repository_url": "https://github.com/codenotary/cas",
-      "website_url": "https://cas.codenotary.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "SIGNING/NOTARY",
-        "AUTHOR"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "Codenotary CAS Notarize Docker Image and SBOM",
-      "publisher": "Codenotary",
-      "description": "A GitHub Action which notarizes and creates an SBOM for Docker images.",
-      "repository_url": "https://github.com/codenotary/cas-notarize-docker-image-bom-github-action",
-      "website_url": "https://cas.codenotary.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "SIGNING/NOTARY",
-        "AUTHOR"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "Codenotary CAS Authenticate Docker Image and SBOM",
-      "publisher": "Codenotary",
-      "description": "A GitHub Action which authenticates notarized Docker images and SBOMs.",
-      "repository_url": "https://github.com/codenotary/cas-authenticate-docker-bom-github-action",
-      "website_url": "https://cas.codenotary.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "SIGNING/NOTARY"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "Cosign",
-      "publisher": "Sigstore",
-      "description": "Container Signing, Verification and Storage in an OCI registry, including CycloneDX SBOMs",
-      "repository_url": "https://github.com/sigstore/cosign",
-      "website_url": "https://sigstore.dev/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "SIGNING/NOTARY",
-        "AUTHOR",
-        "DISTRIBUTE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ]
-    },
-    {
-      "name": "Tern",
-      "publisher": "Tern",
-      "description": "Software composition analysis tool that generates a Software Bill of Materials for container images and Dockerfiles",
-      "repository_url": "https://github.com/tern-tools/tern",
-      "website_url": "https://github.com/tern-tools/tern",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "Cybellum SBOM",
-      "publisher": "Cybellum Technologies LTD.",
-      "description": "Analyzes binary artifacts to generate SBOMs including context-based analysis to perform accurate vulnerability assessment",
-      "website_url": "https://cybellum.com",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "Scancode Toolkit",
-      "publisher": "nexB",
-      "description": "Detects licenses, copyrights, package manifests & dependencies by scanning code to discover and inventory open source and third-party packages",
-      "repository_url": "https://github.com/nexB/scancode-toolkit",
-      "website_url": "https://github.com/nexB/scancode-toolkit",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PERL",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "swift-package-sbom-generator",
-      "publisher": "Mattt",
-      "description": "A software bill of materials (SBOM) generator for Swift packages",
-      "repository_url": "https://github.com/mattt/swift-package-sbom",
-      "website_url": "https://github.com/mattt/swift-package-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "SWIFT"
-      ],
-      "platform": [
-        "MAC"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "SRC:CLR SBOM Generator",
-      "publisher": "Veracode",
-      "description": "Generates a Software Bill of Materials in CycloneDX JSON Format from Veracode SCA Agent results",
-      "repository_url": "https://github.com/veracode/srcclr_sbom_gen",
-      "website_url": "https://github.com/veracode/srcclr_sbom_gen",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "TRANSFORM"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "transform": [
-        "BOM_STANDARD"
-      ]
-    },
-    {
-      "name": "NowSecure Platform",
-      "publisher": "NowSecure",
-      "description": "Mobile application security testing solution that automates static, dynamic and interactive testing, with SBOM capabilities through GitHub integrations",
-      "repository_url": null,
-      "website_url": "https://www.nowsecure.com/products/nowsecure-platform/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "OUTDATED_COMPONENTS"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "Ion Channel Platform",
-      "publisher": "Ion Channel",
-      "description": "Risk management platform that enables analysis, exchange and continuous monitoring of Software Bills of Materials (SBOMs) to actively manage third party risk and compliance",
-      "repository_url": null,
-      "website_url": "https://www.exiger.com/products/ion-channel/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ]
-    },
-    {
-      "name": "CycloneDX for Conan1",
-      "publisher": "CycloneDX",
-      "description": "Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects using Conan1 (note: considered deprecated)",
-      "repository_url": "https://github.com/CycloneDX/cyclonedx-conan",
-      "website_url": "https://pypi.org/project/cyclonedx-conan/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "platform": [
-        "WINDOWS",
-        "LINUX",
-        "MAC"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "supportedLanguages": [
-        "C/C++"
-      ]
-    },
-    {
-      "name": "CycloneDX for Conan2",
-      "publisher": "Conan-IO",
-      "description": "Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects using Conan2",
-      "repository_url": "https://github.com/conan-io/conan-extensions",
-      "website_url": "https://github.com/conan-io/conan-extensions/tree/main/extensions/commands/sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "packaging": [
-        "CONAN_EXTENSION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "platform": [
-        "WINDOWS",
-        "LINUX",
-        "MAC"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2",
-        "CYCLONEDX_V1.1",
-        "CYCLONEDX_V1.0"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "supportedLanguages": [
-        "C/C++"
-      ]
-    },
-    {
-      "name": "Checkov",
-      "publisher": "Checkov",
-      "description": "Prevent cloud misconfigurations during build-time for Terraform, Cloudformation, Kubernetes, Serverless framework and other infrastructure-as-code-languages with Checkov by Bridgecrew. Can output to CycloneDX.",
-      "repository_url": "https://github.com/bridgecrewio/checkov",
-      "website_url": "https://www.checkov.io/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "platform": [
-        "WINDOWS",
-        "LINUX",
-        "MAC"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "PRE-BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "SBOM CLI",
-      "publisher": "Defense Unicorns",
-      "description": "Creates CycloneDX SBOMs from Kubernetes Helm charts",
-      "repository_url": null,
-      "website_url": null,
-      "capabilities": [],
-      "availability": [],
-      "functions": [],
-      "packaging": [],
-      "platform": [],
-      "lifecycle": [],
-      "supportedStandards": [],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "CxSCA",
-      "publisher": "Checkmarx",
-      "description": "Software Composition Analysis (SCA) platform that identifies vulnerabilities, malicious code, and license risks in open-source libraries with exploitable path analysis and SBOM generation capabilities.",
-      "website_url": "https://checkmarx.com/cxsca-open-source-scanning/",
-      "repository_url": "https://checkmarx.com/cxsca-open-source-scanning/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE",
-        "FREEMIUM"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "Ochrona CLI",
-      "publisher": "Ochrona",
-      "description": "A command line tool for detecting vulnerabilities in Python dependencies and doing safe package installs. Outputs CycloneDX SBOMs and supports policy enforcement.",
-      "repository_url": "https://github.com/ochronasec/ochrona-cli",
-      "website_url": "https://ochrona.dev/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "pip-audit",
-      "publisher": "Trail of Bits",
-      "description": "Audits Python environments and dependency trees for known vulnerabilities and can emit CycloneDX SBOMs of affected components.",
-      "repository_url": "https://github.com/pypa/pip-audit",
-      "website_url": "https://github.com/pypa/pip-audit",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "RKVST SBOM Hub",
-      "publisher": "RKVST",
-      "description": "Free SaaS repository to discover, store and permission-share CycloneDX v1.4 SBOMs with immutable provenance, VEX support and continuous assurance.",
-      "repository_url": "https://github.com/jitsuin-inc/archivist-samples",
-      "website_url": "https://www.datatrails.ai/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "FREEMIUM"
-      ],
-      "functions": [
-        "DISTRIBUTE",
-        "SIGNING/NOTARY"
-      ],
-      "analysis": [],
-      "transform": [],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SWID"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "WpBom",
-      "publisher": "Sepbit",
-      "description": "WordPress plugin that generates CycloneDX SBOMs for installed plugins and themes, and can automatically submit them to OWASP Dependency-Track for vulnerability analysis.",
-      "repository_url": "https://github.com/sepbit/wpbom",
-      "website_url": "https://wordpress.org/plugins/wpbom/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [
-        "PHP"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "PHP"
-      ]
-    },
-    {
-      "name": "Meterian BOSS scanner",
-      "publisher": "Meterian",
-      "description": "Software composition analysis that inventories codebases and produces CycloneDX SBOMs while detecting security and licence risks across 12+ ecosystems.",
-      "repository_url": "https://github.com/MeterianHQ/meterian-github-action",
-      "website_url": "https://meterian.io/products/boss",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "FREEMIUM",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "SHELL"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "CPE"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PERL",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "Spack",
-      "publisher": "Spack",
-      "description": "HPC package manager for Linux and macOS; the spack-sbom plug-in exports CycloneDX SBOMs for any concretized spec.",
-      "repository_url": "https://github.com/spack/spack-sbom",
-      "website_url": "https://spack.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "FORTRAN",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "build-info-go",
-      "publisher": "JFrog",
-      "description": "Open-source Go library and CLI that captures build metadata and outputs CycloneDX SBOMs for Java, Node.js, .NET, Go, Python and more.",
-      "repository_url": "https://github.com/jfrog/build-info-go",
-      "website_url": "https://github.com/jfrog/build-info-go",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "Kyverno",
-      "publisher": "Kyverno Project (CNCF Incubating)",
-      "description": "Kyverno is an open-source Kubernetes policy engine that validates, mutates and generates configurations, and can evaluate CycloneDX SBOM attestations to enforce supply-chain policies.",
-      "repository_url": "https://github.com/kyverno/kyverno",
-      "website_url": "https://kyverno.io",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "POLICY_EVALUATION",
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "jbom",
-      "publisher": "Eclipse Foundation (originally Contrast Security)",
-      "description": "jbom generates runtime and static CycloneDX SBOMs for local or remote Java applications and archives.",
-      "repository_url": "https://github.com/eclipse/jbom",
-      "website_url": "https://projects.eclipse.org/projects/technology.jbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "JAVA"
-      ]
-    },
-    {
-      "name": "KICS",
-      "publisher": "Checkmarx",
-      "description": "KICS scans Infrastructure-as-Code to detect security vulnerabilities, compliance issues and misconfigurations, exporting results as CycloneDX SBOM and VDR reports.",
-      "repository_url": "https://github.com/Checkmarx/kics",
-      "website_url": "https://www.kics.io/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "AZURE_PIPELINE_EXTENSION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.3"
-      ]
-    },
-    {
-      "name": "Xray",
-      "publisher": "JFrog",
-      "description": "JFrog Xray is a software-composition-analysis platform that finds vulnerabilities, license issues and policy violations in open-source and third-party components, and can export CycloneDX SBOMs with optional VEX data.",
-      "website_url": "https://jfrog.com/xray/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "FREEMIUM",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "AZURE_PIPELINE_EXTENSION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "CPE"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "C/C++",
-        "PHP"
-      ]
-    },
-    {
-      "name": "apt2sbom",
-      "publisher": "Eliot Lear",
-      "description": "Python tool that builds a Software Bill of Materials (SBOM) from APT and Python package information on Ubuntu systems, with CLI and HTTP interfaces.",
-      "repository_url": "https://github.com/sbomtools/apt2sbom",
-      "website_url": "https://github.com/sbomtools/apt2sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "PACKAGE_MANAGER_INTEGRATION",
-        "AUTHOR"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "APPLICATION"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "DISCOVERY",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "NetRise Platform",
-      "publisher": "NetRise",
-      "description": "The NetRise Platform generates SBOMs for binary code and post-build artifacts. It can ingest and analyze 3rd party SBOMs and provide guidance on risk mitigation, including CVEs, hardcoded credentials, cryptographic risk, and misconfigured services.",
-      "website_url": "https://www.netrise.io/",
-      "repository_url": "https://github.com/netriseinc",
-      "capabilities": [
-        "SBOM",
-        "CBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "RESOURCE_REPORTING",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_STANDARD"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "GITHUB_ACTION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "WINDOWS",
-        "MAC"
-      ],
-      "lifecycle": [
-        "DISCOVERY",
-        "OPERATIONS",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "CPE",
-        "PACKAGE_URL",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        ".NET",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "Rebom",
-      "publisher": "Reliza",
-      "description": "Open source catalog for storing, managing, and distributing CycloneDX Software Bills of Materials (SBOMs) in JSON format, with features for validation, merging, and analysis.",
-      "repository_url": "https://github.com/relizaio/rebom",
-      "website_url": "https://rebomdemo.relizahub.com",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "DISTRIBUTE",
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING",
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [
-        "BOM_VERSION",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "CONTAINER_IMAGE",
-        "APPLICATION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "cve-bin-tool",
-      "publisher": "Intel",
-      "description": "Command-line scanner that identifies vulnerable components in binaries, accepts/generates SBOMs, and reports CVEs. Supports 400+ checkers for open source libraries with CycloneDX output.",
-      "repository_url": "https://github.com/intel/cve-bin-tool",
-      "website_url": "https://cve-bin-tool.readthedocs.io/en/latest/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "CPE",
-        "SPDX",
-        "SWID"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "PYTHON",
-        "JAVASCRIPT/TYPESCRIPT",
-        "ERLANG_ELIXIR",
-        "GO",
-        "RUST"
-      ]
-    },
-    {
-      "name": "Jetstack Secure",
-      "publisher": "Jetstack",
-      "description": "Manages machine identities across Cloud Native Kubernetes and OpenShift environments, providing a detailed view of enterprise security posture for TLS certificates and PKI.",
-      "repository_url": "https://github.com/jetstack/jetstack-secure",
-      "website_url": "https://www.jetstack.io/jetstack-secure/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "CONTAINER_IMAGE",
-        "APPLICATION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Keysight IoT Security Assessment",
-      "publisher": "Keysight",
-      "description": "Automated firmware analysis platform that generates SBOMs and identifies vulnerabilities, misconfigurations, hardcoded credentials, weak cryptography, and potential zero-day vulnerabilities in IoT devices.",
-      "website_url": "https://www.keysight.com/be/en/products/network-security/iot-security-assessment.html",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "DISCOVERY",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Ko",
-      "publisher": "Ko Build",
-      "description": "Simple, fast container image builder for Go applications that generates CycloneDX SBOMs by default, supports multi-platform builds, and integrates seamlessly with Kubernetes.",
-      "repository_url": "https://github.com/ko-build/ko",
-      "website_url": "https://ko.build/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "Sonatype Lift",
-      "publisher": "Sonatype",
-      "description": "Cloud-native, collaborative code analysis platform that analyzes pull requests to find and fix security, performance, reliability, and style issues while generating CycloneDX SBOMs.",
-      "website_url": "https://lift.sonatype.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE",
-        "FREEMIUM"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "GITHUB_APP",
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "GO",
-        "PHP",
-        "RUBY"
-      ]
-    },
-    {
-      "name": "spdxcyclone",
-      "publisher": "SPDX",
-      "description": "Java utility that converts Software Bill of Materials (SBOM) documents from CycloneDX format to SPDX format, supporting multiple serialization options for both standards.",
-      "repository_url": "https://github.com/spdx/cdx2spdx",
-      "website_url": "https://github.com/spdx/cdx2spdx",
-      "capabilities": [],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Trivy",
-      "publisher": "Aqua Security",
-      "description": "Comprehensive security scanner for containers, filesystems, Git repositories, VMs and Kubernetes that detects vulnerabilities, misconfigurations, secrets and generates CycloneDX SBOMs.",
-      "repository_url": "https://github.com/aquasecurity/trivy",
-      "website_url": "https://trivy.dev/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION",
-        "RESOURCE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL",
-        "CPE"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "Apiiro",
-      "publisher": "Apiiro",
-      "description": "Application Security Posture Management (ASPM) platform that proactively identifies and remediates critical risks in cloud-native applications across the software supply chain.",
-      "website_url": "https://apiiro.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DESIGN",
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "JAVA",
-        "PYTHON",
-        "GO",
-        ".NET",
-        "RUST"
-      ]
-    },
-    {
-      "name": "Gemnasium",
-      "publisher": "GitLab",
-      "description": "Dependency scanning analyzer that uses the GitLab Advisory Database to detect vulnerabilities in project dependencies and generates CycloneDX SBOMs.",
-      "repository_url": "https://gitlab.com/gitlab-org/security-products/analyzers/gemnasium",
-      "website_url": "https://docs.gitlab.com/ee/user/application_security/dependency_scanning/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE",
-        "FREEMIUM"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "CONTAINER_IMAGE",
-        "GITLAB_CI_TEMPLATE"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "RUBY",
-        "PYTHON",
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS",
-        "JAVA",
-        "GO",
-        "PHP"
-      ]
-    },
-    {
-      "name": "Lagoon Insights Handler",
-      "publisher": "Lagoon",
-      "description": "Component that processes CycloneDX SBOMs and container image metadata for Lagoon environments, with vulnerability analysis via Trivy integration and customizable data filtering.",
-      "repository_url": "https://github.com/uselagoon/insights-handler",
-      "website_url": "https://lagoon.sh/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "CONTAINER_IMAGE",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "SnykVulnCheck",
-      "publisher": "Andrii Grytsenko",
-      "description": "Command-line tool that analyzes CycloneDX SBOMs and evaluates components for known vulnerabilities by querying the public Snyk Vulnerability Database API.",
-      "repository_url": "https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck",
-      "website_url": "https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck",
-      "capabilities": [
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "apko",
-      "publisher": "Chainguard",
-      "description": "Build OCI images using APK directly without Dockerfile. Generates CycloneDX SBOMs for containers using native SBOM functionality in apk-tools v3.0 and higher.",
-      "repository_url": "https://github.com/chainguard-dev/apko",
-      "website_url": "https://apko.dev/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING",
-        "RESOURCE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "PYTHON",
-        "RUST"
-      ]
-    },
-    {
-      "name": "OSV",
-      "publisher": "Google",
-      "description": "Open source vulnerability database and scanner that accepts CycloneDX SBOMs as input and identifies known vulnerabilities in components across multiple ecosystems.",
-      "repository_url": "https://github.com/google/osv.dev",
-      "website_url": "https://osv.dev/",
-      "capabilities": [
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "PYTHON",
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        ".NET"
-      ]
-    },
-    {
-      "name": "docker-sbom-cli-plugin",
-      "publisher": "Docker",
-      "description": "Docker CLI plugin that generates Software Bills of Materials (SBOMs) for container images using Syft as the underlying scanner, with CycloneDX output support.",
-      "repository_url": "https://github.com/docker/sbom-cli-plugin",
-      "website_url": "https://github.com/docker/sbom-cli-plugin",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO",
-        "SHELL"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "ThreatMapper",
-      "publisher": "Deepfence",
-      "description": "Deepfence ThreatMapper hunts for vulnerabilities in production platforms, ranks vulnerabilities based on their risk-of-exploit using attack path enumeration, and generates CycloneDX SBOMs.",
-      "repository_url": "https://github.com/deepfence/threatmapper",
-      "website_url": "https://deepfence.io/threatmapper",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "CONTAINER_IMAGE",
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "JupiterOne",
-      "publisher": "JupiterOne",
-      "description": "Easily identify, map, analyze, and secure cyber assets and attack surface. Gain full visibility into complex cloud environments to uncover threats, close compliance gaps, and prioritize risk.",
-      "website_url": "https://jupiterone.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "RESOURCE_REPORTING",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [],
-      "platform": [
-        "WINDOWS",
-        "MAC",
-        "LINUX"
-      ],
-      "lifecycle": [
-        "DISCOVERY",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Veracode",
-      "publisher": "Veracode",
-      "description": "API to output SBOM in CycloneDX (JSON) format based on Veracode's software composition analysis (SCA) scan.",
-      "website_url": "https://www.veracode.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION",
-        "GITHUB_ACTION"
-      ],
-      "library": [],
-      "platform": [
-        "WINDOWS",
-        "MAC",
-        "LINUX"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "PYTHON",
-        "RUBY",
-        "GO",
-        "PHP"
-      ]
-    },
-    {
-      "name": "Tidelift",
-      "publisher": "Tidelift",
-      "description": "Tidelift provides a managed open-source subscription that delivers commercial support, maintenance, security and license assurances for the open-source dependencies used to build applications, backed directly by project maintainers.",
-      "repository_url": "https://github.com/tidelift",
-      "website_url": "https://tidelift.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION",
-        "GITLAB_CI_TEMPLATE"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "SWIFT",
-        "GO",
-        "RUST",
-        ".NET",
-        "RUBY",
-        "NODE.JS"
-      ]
-    },
-    {
-      "name": "Bytesafe",
-      "publisher": "Bytesafe",
-      "description": "Bytesafe is a dependency firewall and SCA platform that blocks malicious packages, scans for vulnerabilities, enforces license policies, and generates CycloneDX SBOMs to secure the software supply chain.",
-      "repository_url": "https://github.com/bitfront-se/bytesafe-ce",
-      "website_url": "https://bytesafe.dev/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "FREEMIUM",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "KubeClarity",
-      "publisher": "Cisco",
-      "description": "Open-source platform (CLI, UI & Helm chart) that generates SBOMs, converts them between CycloneDX/SPDX formats, and scans container images, directories and running Kubernetes clusters for vulnerabilities, licences and CIS Docker benchmark findings.",
-      "repository_url": "https://github.com/openclarity/kubeclarity",
-      "website_url": "https://github.com/cisco-open/kubei",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "APPLICATION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PERL",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "Flawnter",
-      "publisher": "CyberTest",
-      "description": "Flawnter is a zero-trust static, dynamic and composition analysis platform that detects code flaws, vulnerabilities and license risks, and generates CycloneDX/SPDX SBOMs during every scan.",
-      "website_url": "https://www.flawnter.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "FREEMIUM",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "C/C++",
-        ".NET",
-        "JAVA",
-        "KOTLIN",
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "GO",
-        "RUBY",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "SonarQube",
-      "publisher": "SonarSource",
-      "description": "SonarQube allows developers and development teams to write clean code and remediate existing code organically, so they can focus on the work they love and maximize the value they generate for businesses.",
-      "repository_url": "https://github.com/SonarSource/sonarqube",
-      "website_url": "https://www.sonarsource.com/products/sonarqube/",
-      "availability": [
-        "OPEN_SOURCE",
-        "FREEMIUM",
-        "COMMERCIAL_LICENSE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "SWIFT",
-        "SCALA",
-        "KOTLIN"
-      ]
-    },
-    {
-      "name": "Black Duck",
-      "publisher": "Synopsys",
-      "description": "Black Duck is Synopsys’ SCA platform that generates CycloneDX/SPDX SBOMs, detects open-source vulnerabilities, and automates license and policy compliance across applications, containers and CI/CD pipelines.",
-      "repository_url": "https://github.com/blackducksoftware/detect",
-      "website_url": "https://www.synopsys.com/software-integrity/security-testing/software-composition-analysis.html",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "AZURE_PIPELINE_EXTENSION",
-        "JENKINS_PLUGIN",
-        "APPLICATION"
-      ],
-      "library": [
-        "JAVA",
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL",
-        "CPE"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PERL",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT",
-        "ERLANG_ELIXIR",
-        "SCALA",
-        "KOTLIN"
-      ]
-    },
-    {
-      "name": "SBOM-Operator",
-      "publisher": "Christian Kotzbauer",
-      "description": "Catalogue all container images running in a Kubernetes cluster and publish Software Bill of Materials (SBOM) documents, generated with Syft, to multiple back-ends.",
-      "repository_url": "https://github.com/ckotzbauer/sbom-operator",
-      "website_url": "https://github.com/ckotzbauer/sbom-operator",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [],
-      "transform": [],
-      "packaging": [
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "yasca (Yet Another SCA tool)",
-      "publisher": "Javi",
-      "description": "Yasca (Yet Another SCA tool) is an open-source Python utility and GitHub Action that scans Maven projects against GitHub Security Advisories, detects vulnerable or outdated dependencies, and exports CycloneDX SBOMs.",
-      "repository_url": "https://github.com/javixeneize/zasca",
-      "website_url": "https://github.com/javixeneize/zasca",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVA"
-      ]
-    },
-    {
-      "name": "Rezilion Dynamic SBOM",
-      "publisher": "Rezilion",
-      "description": "Continuous, runtime-aware SBOM platform that inventories every file, package and dependency across Windows and Linux hosts, containers and CI/CD pipelines, exports CycloneDX/VEX and validates vulnerability exploitability in real time.",
-      "website_url": "https://www.rezilion.com/platform/dynamic-sbom",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "JENKINS_PLUGIN",
-        "GITLAB_CI_TEMPLATE"
-      ],
-      "platform": [
-        "LINUX",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PYTHON",
-        "RUBY"
-      ]
-    },
-    {
-      "name": "BlackBerry Jarvis",
-      "publisher": "BlackBerry",
-      "description": "Software composition analysis (SCA) and security testing solution that detects and lists open-source software and licenses in embedded systems and their cybersecurity vulnerabilities and exposures.",
-      "website_url": "https://blackberry.qnx.com/en/products/security/blackberry-jarvis",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [
-        "C/C++",
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "JAVA"
-      ]
-    },
-    {
-      "name": "Fortify Software Security Center",
-      "publisher": "Micro Focus",
-      "description": "Open-source CycloneDX parser plugin for Fortify SSC that imports SBOMs, correlates components with known vulnerabilities and licenses, and displays them in the SSC portal.",
-      "repository_url": "https://github.com/fortify/fortify-ssc-parser-generic-cyclonedx",
-      "website_url": "https://github.com/fortify/fortify-ssc-parser-generic-cyclonedx",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "CPE",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY"
-      ]
-    },
-    {
-      "name": "sbom-submission-action",
-      "publisher": "TietoEVRY",
-      "description": "GitHub Action that uploads CycloneDX SBOM files to GitHub’s dependency submission API, enabling Dependabot security analysis downstream.",
-      "repository_url": "https://github.com/evryfs/sbom-dependency-submission-action",
-      "website_url": "https://github.com/marketplace/actions/sbom-submission-action",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "DISTRIBUTE"
-      ],
-      "analysis": [],
-      "transform": [],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Vexy",
-      "publisher": "Paul Horton",
-      "description": "Generate VEX (Vulnerability Exploitability Exchange) CycloneDX documents.",
-      "repository_url": "https://github.com/madpah/vexy",
-      "website_url": "https://github.com/madpah/vexy",
-      "capabilities": [
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Project Piper",
-      "publisher": "SAP",
-      "description": "Project Piper is an open-source Jenkins shared library and CLI that automates SAP-centric CI/CD pipelines and can generate CycloneDX SBOMs for Maven, Python, Go, container, and other builds.",
-      "repository_url": "https://github.com/SAP/jenkins-library",
-      "website_url": "https://www.project-piper.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [],
-      "transform": [],
-      "packaging": [
-        "LIBRARY",
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "PYTHON",
-        "GO",
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
     {
       "name": "action-owasp-dependecy-track-check",
       "publisher": "Quobis",
@@ -6832,119 +62,131 @@
         ".NET",
         "PHP",
         "JAVASCRIPT/TYPESCRIPT"
-      ]
+      ],
+      "_fromFile": "action_owasp_dependecy_track_check.json"
     },
     {
-      "name": "LicenseComplianceTool",
-      "publisher": "medavis GmbH",
-      "description": "Creates license manifests from CycloneDX SBOMs. Provides a Jenkins build step and CLI to list third-party components, their licenses, and download license texts to aid open-source compliance.",
-      "repository_url": "https://github.com/medavis-gmbh/LicenseComplianceTool",
-      "website_url": "https://github.com/medavis-gmbh/LicenseComplianceTool",
+      "name": "AI SBOM Generator",
+      "publisher": "Aetheris AI",
+      "description": "Generate AI SBOM (AIBOM, AI/ML-BOM) in CycloneDX format for models on Hugging Face.",
+      "repository_url": "https://github.com/aetheris-ai/aibom-generator/",
+      "website_url": "https://sbom.aetheris.ai",
       "capabilities": [
-        "SBOM"
+        "AI/ML-BOM"
       ],
       "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
+        "OPEN_SOURCE"
       ],
       "functions": [
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "JENKINS_PLUGIN",
-        "COMMAND_LINE_UTILITY"
+        "AUTHOR"
       ],
       "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
+        "PYTHON"
       ],
       "lifecycle": [
         "BUILD",
         "POST-BUILD"
       ],
       "supportedStandards": [
-        "CYCLONEDX"
+        "CYCLONEDX",
+        "PACKAGE_URL"
       ],
-      "supportedLanguages": [
-        "JAVA",
-        "NODE.JS",
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "sbom-action",
-      "publisher": "Pete Wagner",
-      "description": "GitHub Action that fetches and diffs CycloneDX SBOMs for container images, posting comments or opening pull requests when package or vulnerability changes are detected.",
-      "repository_url": "https://github.com/thepwagner/sbom-action",
-      "website_url": "https://github.com/thepwagner/sbom-action",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
       ],
       "platform": [
         "LINUX",
         "MAC",
         "WINDOWS"
       ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
       ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
+      "_fromFile": "ai_sbom_generator.json"
     },
     {
-      "name": "DaggerBoard",
-      "publisher": "NewYork-Presbyterian Hospital",
-      "description": "Vulnerability-scanning application that ingests CycloneDX or SPDX SBOM files, analyses listed dependencies for known CVEs, and presents results through a web dashboard.",
-      "repository_url": "https://github.com/nyph-infosec/daggerboard",
-      "website_url": "https://github.com/nyph-infosec/daggerboard",
+      "name": "Aikido Security",
+      "publisher": "Aikido Security",
+      "description": "Code-to-cloud security in one platform\u2014scan, prioritize, and fix issues across the full stack.",
+      "website_url": "https://aikido.dev",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "FREEMIUM",
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DESIGN",
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "PHP",
+        "JAVA",
+        "SWIFT",
+        "GO",
+        "PYTHON",
+        ".NET",
+        "RUBY",
+        "RUST",
+        "KOTLIN",
+        "ERLANG_ELIXIR",
+        "C/C++",
+        "SCALA"
+      ],
+      "_fromFile": "aikido_security.json"
+    },
+    {
+      "name": "Amazon Inspector SBOM Generator",
+      "publisher": "Amazon Inspector",
+      "description": "Amazon Inspector SBOM Generator (inspector-sbomgen) outputs CycloneDX 1.4 or SPDX 2.3 SBOMs for archives, container images, directories, local systems, and Go/Rust binaries, providing metadata for vulnerability scans with the Inspector ScanSBOM API.",
+      "website_url": "https://docs.aws.amazon.com/inspector/latest/user/sbom-generator.html",
       "capabilities": [
         "SBOM"
       ],
       "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
+        "SUBSCRIPTION"
       ],
       "functions": [
-        "ANALYSIS"
+        "AUTHOR"
       ],
       "analysis": [
-        "SECURITY_VULNERABILITIES"
+        "LICENSE_REPORTING"
       ],
-      "transform": [],
       "packaging": [
-        "APPLICATION",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON",
-        "JAVASCRIPT_TYPESCRIPT"
+        "COMMAND_LINE_UTILITY"
       ],
       "platform": [
         "LINUX"
@@ -6957,16 +199,80 @@
         "SPDX"
       ],
       "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
+        "CYCLONEDX_V1.4"
       ],
-      "supportedLanguages": []
+      "supportedLanguages": [
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "amazon_inspector_sbom_generator.json"
     },
     {
-      "name": "gobom",
-      "publisher": "Mattermost",
-      "description": "An extensible CycloneDX BOM generator and Dependency-Track API client written in Go; supports Go, npm, CocoaPods and Gradle projects and uploads SBOMs for analysis.",
-      "repository_url": "https://github.com/mattermost/gobom",
-      "website_url": "https://github.com/mattermost/gobom",
+      "name": "Apiiro",
+      "publisher": "Apiiro",
+      "description": "Application Security Posture Management (ASPM) platform that proactively identifies and remediates critical risks in cloud-native applications across the software supply chain.",
+      "website_url": "https://apiiro.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DESIGN",
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "JAVA",
+        "PYTHON",
+        "GO",
+        ".NET",
+        "RUST"
+      ],
+      "_fromFile": "apiiro.json"
+    },
+    {
+      "name": "apko",
+      "publisher": "Chainguard",
+      "description": "Build OCI images using APK directly without Dockerfile. Generates CycloneDX SBOMs for containers using native SBOM functionality in apk-tools v3.0 and higher.",
+      "repository_url": "https://github.com/chainguard-dev/apko",
+      "website_url": "https://apko.dev/",
       "capabilities": [
         "SBOM"
       ],
@@ -6976,12 +282,19 @@
       ],
       "functions": [
         "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION"
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING",
+        "RESOURCE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
       ],
       "packaging": [
         "COMMAND_LINE_UTILITY",
-        "LIBRARY"
+        "CONTAINER_IMAGE"
       ],
       "library": [
         "GO"
@@ -6999,404 +312,46 @@
         "CYCLONEDX",
         "PACKAGE_URL"
       ],
-      "supportedLanguages": [
-        "GO",
-        "JAVASCRIPT/TYPESCRIPT",
-        "JAVA",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "sca-codeinsight-reports-cyclonedx",
-      "publisher": "Flexera",
-      "description": "Generates CycloneDX SBOM reports (XML and JSON) for projects scanned in Flexera Code Insight.",
-      "repository_url": "https://github.com/flexera-public/sca-codeinsight-reports-cyclonedx",
-      "website_url": "https://github.com/flexera-public/sca-codeinsight-reports-cyclonedx",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ]
-    },
-    {
-      "name": "meta-dependencytrack",
-      "publisher": "BG Networks",
-      "description": "meta-dependencytrack is a Yocto meta-layer which produces a CycloneDX Software Bill of Materials (aka SBOM) from your root filesystem and then uploads it to a Dependency-Track server against the project of your choice",
-      "repository_url": "https://github.com/bgnetworks/meta-dependencytrack",
-      "website_url": "https://github.com/bgnetworks/meta-dependencytrack",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON",
-        "SHELL"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
-      ]
-    },
-    {
-      "name": "Mend SCA",
-      "publisher": "Mend (Whitesource)",
-      "description": "Mend SCA provides software composition analysis that scans direct and transitive open-source dependencies, enforces security and license policies, and exports CycloneDX or SPDX SBOMs with optional VEX data.",
-      "repository_url": "https://github.com/mend-toolkit/Mend-SBOM-Export-CLI",
-      "website_url": "https://www.mend.io/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "JENKINS_PLUGIN",
-        "AZURE_PIPELINE_EXTENSION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "GO",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "RUBY",
-        "C/C++"
-      ]
-    },
-    {
-      "name": "Prisma Cloud",
-      "publisher": "Palo Alto Networks",
-      "description": "Unified cloud-native application protection platform that scans code, pipelines, infrastructure and runtime to generate CycloneDX SBOMs, analyze vulnerabilities, licenses and misconfigurations, and secure entitlements across multi-cloud environments.",
-      "website_url": "https://www.paloaltonetworks.com/prisma/cloud",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "JENKINS_PLUGIN"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
       "cycloneDxVersion": [
         "CYCLONEDX_V1.4"
       ],
       "supportedLanguages": [
         "C/C++",
         "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
         "PYTHON",
-        "RUBY"
-      ]
+        "RUST"
+      ],
+      "_fromFile": "apko.json"
     },
     {
-      "name": "CAST Highlight",
-      "publisher": "CAST",
-      "description": "CAST Highlight automatically analyzes source code portfolios for open-source risks, cloud readiness, resiliency, green impact and technical debt, and can import CycloneDX SBOMs for instant SCA insights.",
-      "website_url": "https://www.castsoftware.com/products/highlight",
-      "repository_url": "https://github.com/MichaelMULLER/highlight-scan-github-action",
+      "name": "apt2sbom",
+      "publisher": "Eliot Lear",
+      "description": "Python tool that builds a Software Bill of Materials (SBOM) from APT and Python package information on Ubuntu systems, with CLI and HTTP interfaces.",
+      "repository_url": "https://github.com/sbomtools/apt2sbom",
+      "website_url": "https://github.com/sbomtools/apt2sbom",
       "capabilities": [
         "SBOM"
       ],
       "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
+        "OSI_APPROVED"
       ],
       "functions": [
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION"
+        "PACKAGE_MANAGER_INTEGRATION",
+        "AUTHOR"
       ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        ".NET",
-        "NODE.JS",
-        "JAVASCRIPT/TYPESCRIPT",
-        "C/C++",
-        "GO",
-        "PYTHON",
-        "PHP",
-        "RUBY",
-        "SCALA",
-        "KOTLIN"
-      ]
-    },
-    {
-      "name": "CAST SBOM Manager",
-      "publisher": "CAST",
-      "description": "CAST SBOM Manager automates creation, customization and maintenance of SBOMs, adds vulnerability and license insights, and exports them in CycloneDX, Excel and Word with a free tier up to 25 SBOMs.",
-      "website_url": "https://www.castsoftware.com/sbommanager",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "FREEMIUM"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "DISTRIBUTE",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
+      "analysis": [],
       "transform": [
-        "BOM_STANDARD",
         "BOM_SERIALIZATION_FORMAT"
       ],
       "packaging": [
+        "COMMAND_LINE_UTILITY",
         "APPLICATION"
       ],
       "library": [
-        "JAVA"
+        "PYTHON"
       ],
       "platform": [
-        "LINUX",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "Kondukto",
-      "publisher": "Kondukto",
-      "description": "Application Security Orchestration and Correlation platform that generates and consumes CycloneDX or SPDX SBOMs, correlates vulnerability scanner findings, and automates remediation workflows across CI/CD pipelines.",
-      "website_url": "https://kondukto.io",
-      "repository_url": "https://github.com/kondukto-io/kdt",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_STANDARD"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Enso",
-      "publisher": "Enso Security",
-      "description": "Application Security Posture Management (ASPM) platform that inventories software assets, tracks AppSec tools and processes, and outputs CycloneDX and SPDX SBOMs with optional VEX ingest.",
-      "website_url": "https://www.enso.security",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
+        "LINUX"
       ],
       "lifecycle": [
         "DISCOVERY",
@@ -7405,229 +360,47 @@
       "supportedStandards": [
         "CYCLONEDX",
         "SPDX"
-      ]
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "apt2sbom.json"
     },
     {
-      "name": "Tally",
-      "publisher": "Jetstack",
-      "description": "Command-line tool that adds OpenSSF Scorecard security posture scores to packages listed in CycloneDX SBOMs.",
-      "repository_url": "https://github.com/jetstack/tally",
-      "website_url": "https://github.com/jetstack/tally",
+      "name": "ARIANNA",
+      "publisher": "Security Pattern",
+      "description": "SBOM, HBOM and vulnerability management platform for intelligent connect devices. Show compliance to regulations and standards and manage risk across the entire product lifecycle.",
+      "website_url": "https://www.securitypattern.com/arianna-security-management-platform",
       "capabilities": [
-        "SBOM"
+        "SBOM",
+        "HBOM",
+        "VDR/VEX"
       ],
       "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
+        "COMMERCIAL_LICENSE"
       ],
       "functions": [
         "ANALYSIS"
       ],
       "analysis": [
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ]
-    },
-    {
-      "name": "SecureStack",
-      "publisher": "SecureStack",
-      "description": "SecureStack analyzes your application and finds all source code, cloud stack and third-party services and builds a CycloneDX SBOM every time you deploy",
-      "repository_url": "https://github.com/SecureStackCo/actions-sbom",
-      "website_url": "https://securestack.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "FREEMIUM",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "DISTRIBUTE",
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
         "SECURITY_VULNERABILITIES",
         "POLICY_EVALUATION",
-        "RESOURCE_REPORTING",
         "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "supportedLanguages": [
-        "GO",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "SBOM Insights",
-      "publisher": "Revenera",
-      "description": "SBOM Insights is a subscription-based SaaS platform that ingests SBOMs in CycloneDX and SPDX formats, reconciles and analyzes components for vulnerabilities, license compliance and outdated parts, and generates reports and compliance artifacts.",
-      "website_url": "https://www.revenera.com/software-composition-analysis/products/sbom-insights",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "TRANSFORM",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
       ],
       "packaging": [
         "APPLICATION"
       ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "EMBA",
-      "publisher": "EMBA Project",
-      "description": "EMBA is an open-source firmware security analyzer that extracts firmware, performs static and dynamic analysis, builds CycloneDX SBOMs with VEX data, and generates detailed vulnerability reports.",
-      "repository_url": "https://github.com/e-m-b-a/emba",
-      "website_url": "https://www.securefirmware.de",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "SHELL",
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "Spectra Assure",
-      "publisher": "ReversingLabs",
-      "description": "Spectra Assure scans binary software packages, container images, and VM disk images to detect malware, tampering, vulnerabilities, and other exposures. CycloneDX SBOM, SaaSBOM, ML-BOM, and CBOM are outputs.",
-      "repository_url": "https://github.com/reversinglabs/spectra-assure-sdk",
-      "website_url": "https://www.reversinglabs.com/products/software-supply-chain-security",
-      "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "CBOM",
-        "AI/ML-BOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "GITLAB_CI_TEMPLATE",
-        "AZURE_PIPELINE_EXTENSION",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
       "platform": [
         "LINUX",
         "MAC",
         "WINDOWS"
       ],
       "lifecycle": [
+        "DESIGN",
         "BUILD",
-        "POST-BUILD",
         "OPERATIONS"
       ],
       "supportedStandards": [
@@ -7638,21 +411,54 @@
       ],
       "cycloneDxVersion": [
         "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
+        "CYCLONEDX_V1.5"
       ],
       "supportedLanguages": [
         "C/C++",
-        "GO",
         "JAVA",
         "JAVASCRIPT/TYPESCRIPT",
         ".NET",
-        "NODE.JS",
         "PYTHON",
-        "PHP",
-        "RUBY",
-        "RUST"
-      ]
+        "PHP"
+      ],
+      "_fromFile": "arianna.json"
+    },
+    {
+      "name": "Arnica",
+      "publisher": "Arnica",
+      "description": "SaaS platform that automates software supply-chain security; offers free, always-up-to-date SBOM generation in CycloneDX format plus risk analysis and CI/CD integrations.",
+      "website_url": "https://www.arnica.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "FREEMIUM",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "arnica.json"
     },
     {
       "name": "Arsenal",
@@ -7711,2175 +517,8 @@
         "PHP",
         "PYTHON",
         "RUBY"
-      ]
-    },
-    {
-      "name": "Fortify on Demand",
-      "publisher": "Micro Focus",
-      "description": "SaaS application-security testing platform offering SAST, DAST and SCA. Produces and consumes CycloneDX SBOMs to secure the software supply chain across many languages, frameworks and package managers.",
-      "repository_url": "https://github.com/fortify/github-action",
-      "website_url": "https://www.microfocus.com/en-us/cyberres/application-security/fortify-on-demand",
-      "capabilities": [
-        "SBOM"
       ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "SCALA",
-        "KOTLIN",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "SBOMDiff",
-      "publisher": "Anthony Harrison",
-      "description": "SBOMDiff is an Apache-2.0 CLI that compares two SBOM files (CycloneDX 1.4 or SPDX 2.3), highlighting package additions, removals, version or license changes, and outputs text, JSON or YAML reports.",
-      "repository_url": "https://github.com/anthonyharrison/sbomdiff",
-      "website_url": "https://pypi.org/project/sbomdiff/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "SBOM4Python",
-      "publisher": "Anthony Harrison",
-      "description": "CLI utility that produces CycloneDX or SPDX SBOMs for installed Python modules or requirements files, identifying dependencies and their licenses, with optional dependency graph output.",
-      "repository_url": "https://github.com/anthonyharrison/sbom4python",
-      "website_url": "https://pypi.org/project/sbom4python/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "SBOM4Files",
-      "publisher": "Anthony Harrison",
-      "description": "Command-line tool that scans a directory and generates CycloneDX (JSON) or SPDX SBOMs for its files.",
-      "repository_url": "https://github.com/anthonyharrison/sbom4files",
-      "website_url": "https://pypi.org/project/sbom4files/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ]
-    },
-    {
-      "name": "SBOM4Rust",
-      "publisher": "Anthony Harrison",
-      "description": "CLI that reads Cargo.lock and authors CycloneDX v1.6 or SPDX SBOMs for Rust projects.",
-      "repository_url": "https://github.com/anthonyharrison/sbom4rust",
-      "website_url": "https://github.com/anthonyharrison/sbom4rust",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "RUST"
-      ]
-    },
-    {
-      "name": "Distro2SBOM",
-      "publisher": "Anthony Harrison",
-      "description": "A command line tool which creates CycloneDX and SPDX SBOMs for an installed application or distribution (Debian, RPM, Windows and FreeBSD systems supported).",
-      "repository_url": "https://github.com/anthonyharrison/distro2sbom",
-      "website_url": "https://pypi.org/project/distro2sbom/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "TRANSFORM",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "transform": [
-        "BOM_STANDARD"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ]
-    },
-    {
-      "name": "SBOM-Manager",
-      "publisher": "Anthony Harrison",
-      "description": "SBOM-Manager is an open-source Python CLI that stores, queries, and scans CycloneDX 1.4/1.5 and SPDX 2.3 SBOMs via a local repository to support audit and vulnerability investigations.",
-      "repository_url": "https://github.com/anthonyharrison/sbom-manager",
-      "website_url": "https://pypi.org/project/sbom-manager/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "SBOMAudit",
-      "publisher": "Anthony Harrison",
-      "description": "SBOMAudit is a command-line utility that audits CycloneDX or SPDX SBOMs against NTIA minimum requirements, license policies, allow/deny lists, and package age to flag outdated or non-compliant components.",
-      "repository_url": "https://github.com/anthonyharrison/sbomaudit",
-      "website_url": "https://pypi.org/project/sbomaudit/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "CPE",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "PERL",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "SBOM2doc",
-      "publisher": "Anthony Harrison",
-      "description": "SBOM2doc converts CycloneDX or SPDX SBOMs into human-readable reports in PDF, Markdown, HTML, Excel or console formats via a cross-platform Python CLI.",
-      "repository_url": "https://github.com/anthonyharrison/sbom2doc",
-      "website_url": "https://pypi.org/project/sbom2doc/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "SBOM2dot",
-      "publisher": "Anthony Harrison",
-      "description": "CLI that reads CycloneDX or SPDX SBOMs and emits a GraphViz-compatible DOT file so you can visualise component and dependency relationships.",
-      "repository_url": "https://github.com/anthonyharrison/sbom2dot",
-      "website_url": "https://pypi.org/project/sbom2dot/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM",
-        "ANALYSIS"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "SBOMMerge",
-      "publisher": "Anthony Harrison",
-      "description": "Command-line utility that merges two SBOM files, supporting CycloneDX and SPDX inputs and outputs in tag, JSON or YAML formats.",
-      "repository_url": "https://github.com/anthonyharrison/sbommerge",
-      "website_url": "https://pypi.org/project/sbommerge/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "Lib4sbom",
-      "publisher": "Anthony Harrison",
-      "description": "Python library that parses, converts and generates SBOMs in CycloneDX and SPDX formats, allowing JSON, Tag, YAML and XML serialization and programmatic manipulation of packages, files and dependencies.",
-      "repository_url": "https://github.com/anthonyharrison/lib4sbom",
-      "website_url": "https://pypi.org/project/lib4sbom/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ]
-    },
-    {
-      "name": "bomber",
-      "publisher": "DevOps Kung Fu Mafia",
-      "description": "CLI scanner that analyses CycloneDX, SPDX or Syft SBOMs for security vulnerabilities and licence issues using OSV, Sonatype OSS Index, GitHub Advisory or Snyk providers.",
-      "repository_url": "https://github.com/devops-kung-fu/bomber",
-      "website_url": "https://github.com/devops-kung-fu/bomber",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Covenant",
-      "publisher": "Patrik Svensson",
-      "description": "Command-line tool that creates SBOMs from .NET and NPM projects or existing CycloneDX BOMs, outputting CycloneDX or SPDX formats.",
-      "repository_url": "https://github.com/patriksvensson/covenant",
-      "website_url": "https://github.com/patriksvensson/covenant",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        ".NET"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "supportedLanguages": [
-        ".NET",
-        "JAVASCRIPT/TYPESCRIPT",
-        "NODE.JS"
-      ]
-    },
-    {
-      "name": "ONEKEY firmware analysis platform",
-      "publisher": "ONEKEY",
-      "description": "Cloud-based platform that automatically extracts firmware images, enumerates components, and produces CycloneDX SBOM and vulnerability reports.",
-      "website_url": "https://onekey.com/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "OUTDATED_COMPONENTS",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ]
-    },
-    {
-      "name": "Vuls",
-      "publisher": "Future Corp",
-      "description": "Agent-less vulnerability scanner for Linux, FreeBSD, containers, WordPress, programming language libraries and network devices which outputs CycloneDX Vulnerability Disclosure Reports (VDR).",
-      "repository_url": "https://github.com/future-architect/vuls",
-      "website_url": "https://vuls.io/",
-      "capabilities": [
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "StackAware",
-      "publisher": "StackAware",
-      "description": "StackAware is a SaaS platform for managing CycloneDX 1.4/1.5 and SPDX SBOMs, enriching them with VEX data, and securely distributing both SBOMs and SaaSBOMs for supply-chain risk analysis.",
-      "website_url": "https://stackaware.com/",
-      "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "Manifest",
-      "publisher": "Manifest",
-      "description": "Manifest is a subscription SBOM management platform that auto-generates, aggregates, enriches, analyzes, and securely shares CycloneDX or SPDX SBOMs via web app and GitHub Action integration.",
-      "repository_url": "https://github.com/manifest-cyber/manifest-github-action",
-      "website_url": "https://manifestcyber.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ]
-    },
-    {
-      "name": "Valint",
-      "publisher": "Scribe Security",
-      "description": "CLI and CI/CD tool for generating CycloneDX SBOMs, signing and verifying supply-chain evidence, enforcing policy, and tracking vulnerabilities across containers, source repositories, and pipelines.",
-      "repository_url": "https://github.com/scribe-security/gatekeeper-valint",
-      "website_url": "https://scribesecurity.com/scribe-platform-lp",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "SIGNING/NOTARY",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "AZURE_PIPELINE_EXTENSION"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "Debricked",
-      "publisher": "OpenText",
-      "description": "Debricked lets teams automatically find, fix and prevent open-source vulnerabilities, avoid non-compliant licences and pick healthier dependencies, with CycloneDX SBOM import/export, CLI and SaaS dashboards.",
-      "repository_url": "https://github.com/debricked/cli",
-      "website_url": "https://debricked.com/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "FREEMIUM"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DESIGN",
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "PHP",
-        "PYTHON",
-        "RUBY"
-      ]
-    },
-    {
-      "name": "EXPLIoT IoT Security Assessment Framework",
-      "publisher": "EXPLIoT",
-      "description": "EXPLIoT is an AGPLv3 Python framework and CLI for assessing and exploiting IoT devices; it offers 140+ plug-ins and can generate CycloneDX SBOMs from firmware filesystems.",
-      "repository_url": "https://gitlab.com/expliot_framework/expliot",
-      "website_url": "https://expliot.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Endor Labs",
-      "publisher": "Endor Labs",
-      "description": "Cloud-native platform that auto-creates CycloneDX SBOMs, generates VEX, and analyzes reachability so teams can securely select, integrate and maintain open-source software at scale.",
-      "website_url": "https://endorlabs.com",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "GITHUB_ACTION",
-        "GITLAB_CI_TEMPLATE"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY"
-      ]
-    },
-    {
-      "name": "Value Stream Management (VSM)",
-      "publisher": "LeanIX",
-      "description": "SaaS catalog that ingests CycloneDX SBOMs via REST API, indexes them by team and product, and surfaces vulnerabilities, licenses and component age to secure the software supply chain.",
-      "website_url": "https://www.leanix.net/en/products/value-stream-management",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ]
-    },
-    {
-      "name": "RapidFort",
-      "publisher": "RapidFort",
-      "description": "Container-optimization platform that scans, profiles and hardens images, generates SBOMs, converts to CycloneDX/SPDX, and exports VEX to prioritize exploitable CVEs.",
-      "website_url": "https://www.rapidfort.com/",
-      "repository_url": "https://github.com/rapidfort/community-images",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "TRANSFORM",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ]
-    },
-    {
-      "name": "FOSSA",
-      "publisher": "FOSSA",
-      "description": "Subscription SCA platform and CLI that generate, import, analyse, and distribute CycloneDX or SPDX SBOMs for licence and vulnerability risk management across CI/CD pipelines.",
-      "repository_url": "https://github.com/fossas/fossa-cli",
-      "website_url": "https://fossa.com",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [
-        "BOM_STANDARD"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "SBOM Quality Score",
-      "publisher": "Interlynk.io",
-      "description": "Command-line utility that evaluates the quality and compliance of CycloneDX and SPDX SBOMs across multiple categories, enabling automated policy gates in CI/CD workflows.",
-      "repository_url": "https://github.com/interlynk-io/sbomqs",
-      "website_url": "https://www.interlynk.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ]
-    },
-    {
-      "name": "SBOM Grep",
-      "publisher": "Interlynk.io",
-      "description": "Command-line utility (`sbomgr`) that performs grep-style searches across SBOMs by name, checksum, CPE, and PURL.",
-      "repository_url": "https://github.com/interlynk-io/sbomgr",
-      "website_url": "https://www.interlynk.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ]
-    },
-    {
-      "name": "SBOM Explorer",
-      "publisher": "Interlynk.io",
-      "description": "sbomex is a command line utility to help query and pull from Interlynk's public SBOM repository.",
-      "repository_url": "https://github.com/interlynk-io/sbomex",
-      "website_url": "https://www.interlynk.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "DISTRIBUTE"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ]
-    },
-    {
-      "name": "SBOM Benchmark",
-      "publisher": "Interlynk.io",
-      "description": "SBOM Benchmark is an Apache-licensed web application that scores CycloneDX 1.4/1.5 and SPDX SBOMs for quality and compliance, generating shareable reports via the sbomqs engine.",
-      "repository_url": "https://github.com/interlynk-io/sbombenchmark.dev",
-      "website_url": "https://sbombenchmark.dev/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED",
-        "FREEMIUM"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "Amazon Inspector SBOM Generator",
-      "publisher": "Amazon Inspector",
-      "description": "Amazon Inspector SBOM Generator (inspector-sbomgen) outputs CycloneDX 1.4 or SPDX 2.3 SBOMs for archives, container images, directories, local systems, and Go/Rust binaries, providing metadata for vulnerability scans with the Inspector ScanSBOM API.",
-      "website_url": "https://docs.aws.amazon.com/inspector/latest/user/sbom-generator.html",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "Xygeni Software Supply-Chain Security",
-      "publisher": "Xygeni",
-      "description": "Supply-chain security platform and CLI that generates CycloneDX SBOMs, analyses vulnerabilities and misconfigurations, enforces policy in CI/CD, and integrates with DevOps tools to secure releases.",
-      "repository_url": "https://github.com/xygeni/xygeni-action",
-      "website_url": "https://xygeni.io/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "JENKINS_PLUGIN"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "GO",
-        ".NET"
-      ]
-    },
-    {
-      "name": "SBOM Utility (sbom-utility)",
-      "publisher": "CycloneDX",
-      "description": "Go-based CLI and API to validate, query, trim and patch CycloneDX or SPDX BOMs, report on components, licences and vulnerabilities, and handle all CycloneDX variants up to v1.6.",
-      "repository_url": "https://github.com/CycloneDX/sbom-utility",
-      "website_url": "https://github.com/CycloneDX/sbom-utility",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ]
-    },
-    {
-      "name": "License Scanner",
-      "publisher": "CycloneDX",
-      "description": "license-scanner is an Apache-2.0 Go library and CLI that detects SPDX-style licenses and legal terms in source files and outputs CycloneDX v1.4 SBOMs with detailed license data.",
-      "repository_url": "https://github.com/CycloneDX/license-scanner",
-      "website_url": "https://github.com/CycloneDX/license-scanner",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "gh-sbom",
-      "publisher": "GitHub",
-      "description": "CLI extension for the gh tool that generates CycloneDX or SPDX JSON SBOMs for any GitHub repository using Dependency Graph data.",
-      "repository_url": "https://github.com/advanced-security/gh-sbom",
-      "website_url": "https://github.com/advanced-security/gh-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "SecObserve",
-      "publisher": "MaibornWolff",
-      "description": "Open-source platform that aggregates findings and CycloneDX SBOMs from many scanners, lets teams assess security and license risks, and reports results via dashboards and APIs.",
-      "repository_url": "https://github.com/MaibornWolff/SecObserve",
-      "website_url": "https://maibornwolff.github.io/SecObserve",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON",
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "KOTLIN"
-      ]
-    },
-    {
-      "name": "Vulert Vulnerability Scanner",
-      "publisher": "Vulert.com",
-      "description": "Web SCA service that analyzes CycloneDX or SPDX SBOMs (or lockfiles) to flag open-source vulnerabilities and license issues, sending real-time alerts without requiring code access or signup.",
-      "website_url": "https://vulert.com/abom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "FREEMIUM"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ]
-    },
-    {
-      "name": "Vigiles",
-      "publisher": "Timesys",
-      "description": "Vulnerability monitoring and remediation suite that imports, generates, converts, and analyses CycloneDX or SPDX SBOMs with curated CVE feeds and build-system integrations for Yocto, Buildroot, OpenWrt, and more.",
-      "repository_url": "https://github.com/TimesysGit/vigiles-cli",
-      "website_url": "https://www.timesys.com/solutions/vigiles-vulnerability-management/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [
-        "BOM_STANDARD"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "Arnica",
-      "publisher": "Arnica",
-      "description": "SaaS platform that automates software supply-chain security; offers free, always-up-to-date SBOM generation in CycloneDX format plus risk analysis and CI/CD integrations.",
-      "website_url": "https://www.arnica.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "FREEMIUM",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "Technolinator",
-      "publisher": "MediaMarktSaturn Technology",
-      "description": "GitHub App that generates CycloneDX SBOMs with cdxgen, scans them for vulnerabilities using grype, and uploads results to Dependency-Track.",
-      "repository_url": "https://github.com/MediaMarktSaturn/technolinator",
-      "website_url": "https://github.com/MediaMarktSaturn/technolinator",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "GITHUB_APP",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ]
-    },
-    {
-      "name": "FACT",
-      "publisher": "aDolus Technology Inc.",
-      "description": "The aDolus FACT platform is an advanced aggregation, analytics, and correlation engine that generates NTIA-compliant SBOMs (including CycloneDX) and provides continuous cybersecurity risk intelligence across the software supply chain.",
-      "website_url": "https://adolus.com",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "lifecycle": [
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "SWID"
-      ]
-    },
-    {
-      "name": "Parlay",
-      "publisher": "Snyk",
-      "description": "Parlay is an Apache-licensed CLI written in Go that takes CycloneDX 1.4 JSON/XML or SPDX 2.3 SBOMs and enriches them with licence, vulnerability, maintainer and scorecard data from services like ecosyste.ms, Snyk and OpenSSF.",
-      "repository_url": "https://github.com/snyk/parlay",
-      "website_url": "https://github.com/snyk/parlay",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "Beniva Software Bill of Materials (SBOM)",
-      "publisher": "Beniva",
-      "description": "Beniva SBOM allows you to consume CycloneDX SBOM and Vulnerability Exploitability eXchange (VEX) within the ServiceNow platform which increases visibility of vulnerabilities and reduces time to remediate.",
-      "website_url": "https://store.servicenow.com/sn_appstore_store.do#!/store/application/1f62663a1ba19dd06921a821604bcb98",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "lifecycle": [
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "bombon",
-      "publisher": "nikstur",
-      "description": "CLI and Nix library that generates CycloneDX v1.5 SBOMs for Nix packages, including build-time and vendored dependencies, compliant with BSI TR-03183 and US EO 14028.",
-      "repository_url": "https://github.com/nikstur/bombon",
-      "website_url": "https://github.com/nikstur/bombon",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "packaging": [
-        "LIBRARY",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "RUST"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3"
-      ]
-    },
-    {
-      "name": "Continuous Clearing",
-      "publisher": "Siemens",
-      "description": "Scans third-party OSS components in NPM, NuGet, Maven, Python and Debian projects, generates CycloneDX SBOMs, then uploads them to SW360 and Fossology for automated license clearing.",
-      "repository_url": "https://github.com/siemens/continuous-clearing",
-      "website_url": "https://github.com/siemens/continuous-clearing",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        ".NET"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "CaPyCli - Clearing Automation for SW360",
-      "publisher": "Siemens",
-      "description": "CaPyCli is an MIT-licensed Python CLI that generates, compares, merges and converts CycloneDX SBOMs for several language ecosystems and maps them to a SW360 component database.",
-      "repository_url": "https://github.com/sw360/capycli",
-      "website_url": "https://github.com/sw360/capycli",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "cyclonedx-editor-validator",
-      "publisher": "Festo SE & Co. KG",
-      "description": "Command-line utility to create, merge, edit and validate CycloneDX SBOMs and VEX files for automated CI/CD workflows.",
-      "repository_url": "https://github.com/Festo-se/cyclonedx-editor-validator",
-      "website_url": "https://festo-se.github.io/cyclonedx-editor-validator/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT"
-      ]
-    },
-    {
-      "name": "vsm-sbom-booster",
-      "publisher": "LeanIX",
-      "description": "CLI and Docker-based tool that scans Git providers, runs ORT, generates CycloneDX SBOMs centrally, and uploads them to LeanIX VSM to speed onboarding.",
-      "repository_url": "https://github.com/leanix/vsm-sbom-booster",
-      "website_url": "https://github.com/leanix/vsm-sbom-booster",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "DISTRIBUTE"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "KOTLIN"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "KOTLIN",
-        "SCALA",
-        "SWIFT"
-      ]
+      "_fromFile": "arsenal.json"
     },
     {
       "name": "asdf-cyclonedx",
@@ -9916,568 +555,8 @@
       "cycloneDxVersion": [
         "CYCLONEDX_V1.6",
         "CYCLONEDX_V1.5"
-      ]
-    },
-    {
-      "name": "cdx-central",
-      "publisher": "nscuro",
-      "description": "CLI utility that downloads public CycloneDX SBOMs from Maven Central for selected artifacts.",
-      "repository_url": "https://github.com/nscuro/cdx-central",
-      "website_url": "https://github.com/nscuro/cdx-central",
-      "capabilities": [
-        "SBOM"
       ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "DISTRIBUTE"
-      ],
-      "analysis": [],
-      "transform": [],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [],
-      "supportedLanguages": []
-    },
-    {
-      "name": "cdx-vs-cdx",
-      "publisher": "marcosanchotene",
-      "description": "GTK-style Python GUI that compares two CycloneDX JSON SBOMs, highlighting components unique to each file and those present in both.",
-      "repository_url": "https://github.com/marcosanchotene/cdx-vs-cdx",
-      "website_url": "https://github.com/marcosanchotene/cdx-vs-cdx",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ]
-    },
-    {
-      "name": "cyclonedx-npm-pipe",
-      "publisher": "ShiftLeftCyber",
-      "description": "Bitbucket Pipe that packages cdxgen in a Docker image to generate CycloneDX v1.6 SBOMs for Node.js/npm projects in CI pipelines.",
-      "repository_url": "https://github.com/ccideas/cyclonedx-npm-pipe",
-      "website_url": "https://shiftleftcyber.io",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "SHELL"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "NODE.JS"
-      ]
-    },
-    {
-      "name": "macaron",
-      "publisher": "Oracle",
-      "description": "Macaron is a supply chain security analysis tool and policy engine that checks conformance to frameworks such as SLSA, integrating CycloneDX SBOM generators or consuming existing SBOMs for automated analysis of build integrity and dependencies.",
-      "repository_url": "https://github.com/oracle/macaron",
-      "website_url": "https://oracle.github.io/macaron/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON",
-        "SHELL"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC"
-      ],
-      "lifecycle": [
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ]
-    },
-    {
-      "name": "kbom - Kubernetes Bill of Materials powered by KSOC",
-      "publisher": "KSOC",
-      "description": "kbom is an open-source CLI tool from KSOC, written in Go, that generates detailed CycloneDX SBOMs for Kubernetes clusters, including nodes, control plane, OS, and cloud infrastructure details.",
-      "repository_url": "https://github.com/rad-security/kbom",
-      "website_url": "https://github.com/rad-security/kbom",
-      "capabilities": [
-        "SBOM",
-        "OBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4"
-      ]
-    },
-    {
-      "name": "SBOM Scorecard",
-      "publisher": "eBay",
-      "description": "SBOM Scorecard evaluates SBOMs for specification compliance, generation metadata, and package details, supporting CycloneDX, SPDX, and Syft formats.",
-      "repository_url": "https://github.com/eBay/sbom-scorecard",
-      "website_url": "https://github.com/eBay/sbom-scorecard",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "library": [
-        "GO"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "SBOM Observer",
-      "publisher": "Bytesafe",
-      "description": "SBOM Observer provides a comprehensive SBOM workflow to help you manage your software supply chain. Leverage the powerful combination of the Policy Engine and Operational Model to guarantee the security and compliance of your software.",
-      "website_url": "https://sbom.observer/",
-      "repository_url": "https://github.com/marketplace/actions/sbom-observer-scan-and-upload",
-      "capabilities": [
-        "SBOM",
-        "RELEASE_NOTES",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "RESOURCE_REPORTING",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION",
-        "CONTAINER_IMAGE"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "SLSA"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PERL",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT",
-        "ERLANG_ELIXIR",
-        "SCALA",
-        "KOTLIN",
-        "GROOVY",
-        "FORTRAN"
-      ]
-    },
-    {
-      "name": "SBOM Assembler",
-      "publisher": "Interlynk.io",
-      "description": "sbomasm is a command-line tool that assembles product SBOMs from component SBOMs, supporting CycloneDX and SPDX formats for streamlined management and distribution.",
-      "repository_url": "https://github.com/interlynk-io/sbomasm",
-      "website_url": "https://www.interlynk.io/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "GO"
-      ]
-    },
-    {
-      "name": "Neo4Cyclone",
-      "publisher": "Javier Dominguez",
-      "description": "Neo4Cyclone is a tool that allows you to visualise your SBOMs using Neo4J.",
-      "repository_url": "https://github.com/javixeneize/neo4cyclone",
-      "website_url": "https://github.com/javixeneize/neo4cyclone",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "SBOMcenter",
-      "publisher": "Codenotary Inc",
-      "description": "SBOMcenter.io is a free service to get insights into the ingredients of your software for free and without any software.",
-      "website_url": "https://sbomcenter.io",
-      "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "FREEMIUM"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION",
-        "CONTAINER_IMAGE"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "PYTHON",
-        "JAVASCRIPT/TYPESCRIPT",
-        "GO",
-        "RUST"
-      ]
-    },
-    {
-      "name": "SBOM.sh",
-      "publisher": "Codenotary Inc",
-      "description": "SBOM.sh is a free service to store, visualize and globally share CycloneDX SBOM files by simply using HTTP requests or curl.",
-      "repository_url": "https://github.com/codenotary/sbom.sh-container",
-      "website_url": "https://sbom.sh",
-      "capabilities": [
-        "SBOM",
-        "RELEASE_NOTES"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "FREEMIUM"
-      ],
-      "functions": [
-        "DISTRIBUTE",
-        "AUTHOR",
-        "SIGNING/NOTARY"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "SHELL"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST"
-      ]
-    },
-    {
-      "name": "Vulnerabilities.io",
-      "publisher": "Vulnerabilities Input Output Limited",
-      "description": "Generates CycloneDX Software Bill of Materials (SBOM) and visualizations for an organization's codebase through integrations with source control systems. Enables organizations to manage overall supply chain risk.",
-      "website_url": "https://www.vulnerabilities.io",
-      "repository_url": "https://www.vulnerabilities.io",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS"
-      ],
-      "packaging": [
-        "GITHUB_APP",
-        "COMMAND_LINE_UTILITY"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        ".NET",
-        "PHP",
-        "PYTHON",
-        "JAVASCRIPT/TYPESCRIPT",
-        "RUST",
-        "ERLANG_ELIXIR"
-      ]
+      "_fromFile": "asdf_cyclonedx.json"
     },
     {
       "name": "Athena",
@@ -10583,16 +662,605 @@
         "KOTLIN",
         "GROOVY",
         "FORTRAN"
-      ]
+      ],
+      "_fromFile": "athena.json"
     },
     {
-      "name": "Semgrep",
-      "publisher": "Semgrep Inc",
-      "description": "Semgrep is an application security platform where developers can scan for vulnerabilities in code (SAST), in OSS dependencies (SCA), and secrets. Semgrep creates CycloneDX SBOMs that enrich vulnerabilities with reachability analysis.",
-      "website_url": "https://semgrep.dev",
-      "repository_url": "https://github.com/semgrep/semgrep",
+      "name": "Auditjs",
+      "publisher": "Sonatype",
+      "description": "Audits JavaScript projects to identify known vulnerabilities and outdated package versions using the OSS Index v3 REST API",
+      "repository_url": "https://github.com/sonatype-nexus-community/auditjs",
+      "website_url": "https://github.com/sonatype-nexus-community/auditjs",
       "capabilities": [
         "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "auditjs.json"
+    },
+    {
+      "name": "Beniva Software Bill of Materials (SBOM)",
+      "publisher": "Beniva",
+      "description": "Beniva SBOM allows you to consume CycloneDX SBOM and Vulnerability Exploitability eXchange (VEX) within the ServiceNow platform which increases visibility of vulnerabilities and reduces time to remediate.",
+      "website_url": "https://store.servicenow.com/sn_appstore_store.do#!/store/application/1f62663a1ba19dd06921a821604bcb98",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "lifecycle": [
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "beniva_software_bill_of_materials_sbom_.json"
+    },
+    {
+      "name": "Bitbucket Pipe for SBOM Generation",
+      "publisher": "ShiftLeftCyber",
+      "description": "Integrate this Bitbucket Pipe into your CI/CD pipeline to automatically generate a Software Bill of Materials (SBOM) for any project.",
+      "repository_url": "https://github.com/shiftleftcyber/syft-bitbucket-pipe",
+      "website_url": "https://shiftleftcyber.io",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "library": [
+        "SHELL"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "GITHUB_ACTION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT",
+        "ERLANG_ELIXIR",
+        "SCALA"
+      ],
+      "_fromFile": "bitbucket_pipe_for_sbom_generation.json"
+    },
+    {
+      "name": "Black Duck",
+      "publisher": "Synopsys",
+      "description": "Black Duck is Synopsys\u2019 SCA platform that generates CycloneDX/SPDX SBOMs, detects open-source vulnerabilities, and automates license and policy compliance across applications, containers and CI/CD pipelines.",
+      "repository_url": "https://github.com/blackducksoftware/detect",
+      "website_url": "https://www.synopsys.com/software-integrity/security-testing/software-composition-analysis.html",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "AZURE_PIPELINE_EXTENSION",
+        "JENKINS_PLUGIN",
+        "APPLICATION"
+      ],
+      "library": [
+        "JAVA",
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL",
+        "CPE"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT",
+        "ERLANG_ELIXIR",
+        "SCALA",
+        "KOTLIN"
+      ],
+      "_fromFile": "black_duck.json"
+    },
+    {
+      "name": "BlackBerry Jarvis",
+      "publisher": "BlackBerry",
+      "description": "Software composition analysis (SCA) and security testing solution that detects and lists open-source software and licenses in embedded systems and their cybersecurity vulnerabilities and exposures.",
+      "website_url": "https://blackberry.qnx.com/en/products/security/blackberry-jarvis",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [
+        "C/C++",
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "JAVA"
+      ],
+      "_fromFile": "blackberry_jarvis.json"
+    },
+    {
+      "name": "bogrod",
+      "publisher": "productaize",
+      "description": "A command line tool to manage SBOM and VEX like source code and to distribute SBOMs to notaries.",
+      "repository_url": "https://github.com/productaize/bogrod",
+      "website_url": "https://github.com/productaize/bogrod",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "bogrod.json"
+    },
+    {
+      "name": "BOM Repository Server",
+      "publisher": "CycloneDX",
+      "description": "A lightweight repository server used to publish, manage, and distribute CycloneDX SBOMs.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-bom-repo-server",
+      "website_url": "https://github.com/CycloneDX/cyclonedx-bom-repo-server",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "DISTRIBUTE"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "CONTAINER_IMAGE"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "_fromFile": "bom_repository_server.json"
+    },
+    {
+      "name": "bomber",
+      "publisher": "DevOps Kung Fu Mafia",
+      "description": "CLI scanner that analyses CycloneDX, SPDX or Syft SBOMs for security vulnerabilities and licence issues using OSV, Sonatype OSS Index, GitHub Advisory or Snyk providers.",
+      "repository_url": "https://github.com/devops-kung-fu/bomber",
+      "website_url": "https://github.com/devops-kung-fu/bomber",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "bomber.json"
+    },
+    {
+      "name": "bombon",
+      "publisher": "nikstur",
+      "description": "CLI and Nix library that generates CycloneDX v1.5 SBOMs for Nix packages, including build-time and vendored dependencies, compliant with BSI TR-03183 and US EO 14028.",
+      "repository_url": "https://github.com/nikstur/bombon",
+      "website_url": "https://github.com/nikstur/bombon",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "packaging": [
+        "LIBRARY",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "RUST"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3"
+      ],
+      "_fromFile": "bombon.json"
+    },
+    {
+      "name": "BOMnipotent",
+      "publisher": "Weichwerke Heidrich Software",
+      "description": "A server application for managing and distributing SBOMs and CSAF documents. Integrates with tools for vulnerability scanning.",
+      "website_url": "https://www.bomnipotent.de",
+      "repository_url": "https://github.com/Weichwerke-Heidrich-Software/bomnipotent_doc",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "DISTRIBUTE"
+      ],
+      "library": [
+        "SHELL"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "CPE"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "bomnipotent.json"
+    },
+    {
+      "name": "BOMSkope",
+      "publisher": "Netskope",
+      "description": "BOMSkope is a Software Bill of Materials manager designed to streamline the tracking of vendor components. It enables the identification and monitoring of vulnerabilities in vendor software, enhancing visibility into your overall security posture.",
+      "repository_url": "https://github.com/netskopeoss/BOMSkope",
+      "website_url": "https://github.com/netskopeoss/BOMSkope",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "bomskope.json"
+    },
+    {
+      "name": "build-info-go",
+      "publisher": "JFrog",
+      "description": "Open-source Go library and CLI that captures build metadata and outputs CycloneDX SBOMs for Java, Node.js, .NET, Go, Python and more.",
+      "repository_url": "https://github.com/jfrog/build-info-go",
+      "website_url": "https://github.com/jfrog/build-info-go",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PYTHON"
+      ],
+      "_fromFile": "build_info_go.json"
+    },
+    {
+      "name": "Bytesafe",
+      "publisher": "Bytesafe",
+      "description": "Bytesafe is a dependency firewall and SCA platform that blocks malicious packages, scans for vulnerabilities, enforces license policies, and generates CycloneDX SBOMs to secure the software supply chain.",
+      "repository_url": "https://github.com/bitfront-se/bytesafe-ce",
+      "website_url": "https://bytesafe.dev/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
       ],
       "availability": [
         "OPEN_SOURCE",
@@ -10603,6 +1271,177 @@
         "ANALYSIS",
         "AUTHOR",
         "PACKAGE_MANAGER_INTEGRATION",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PYTHON"
+      ],
+      "_fromFile": "bytesafe.json"
+    },
+    {
+      "name": "CaPyCli - Clearing Automation for SW360",
+      "publisher": "Siemens",
+      "description": "CaPyCli is an MIT-licensed Python CLI that generates, compares, merges and converts CycloneDX SBOMs for several language ecosystems and maps them to a SW360 component database.",
+      "repository_url": "https://github.com/sw360/capycli",
+      "website_url": "https://github.com/sw360/capycli",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
+      ],
+      "_fromFile": "capycli_clearing_automation_for_sw360.json"
+    },
+    {
+      "name": "CAST Highlight",
+      "publisher": "CAST",
+      "description": "CAST Highlight automatically analyzes source code portfolios for open-source risks, cloud readiness, resiliency, green impact and technical debt, and can import CycloneDX SBOMs for instant SCA insights.",
+      "website_url": "https://www.castsoftware.com/products/highlight",
+      "repository_url": "https://github.com/MichaelMULLER/highlight-scan-github-action",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS",
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        ".NET",
+        "NODE.JS",
+        "JAVASCRIPT/TYPESCRIPT",
+        "C/C++",
+        "GO",
+        "PYTHON",
+        "PHP",
+        "RUBY",
+        "SCALA",
+        "KOTLIN"
+      ],
+      "_fromFile": "cast_highlight.json"
+    },
+    {
+      "name": "CAST SBOM Manager",
+      "publisher": "CAST",
+      "description": "CAST SBOM Manager automates creation, customization and maintenance of SBOMs, adds vulnerability and license insights, and exports them in CycloneDX, Excel and Word with a free tier up to 25 SBOMs.",
+      "website_url": "https://www.castsoftware.com/sbommanager",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "FREEMIUM"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "DISTRIBUTE",
         "TRANSFORM"
       ],
       "analysis": [
@@ -10611,7 +1450,336 @@
         "OUTDATED_COMPONENTS"
       ],
       "transform": [
+        "BOM_STANDARD",
         "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "cast_sbom_manager.json"
+    },
+    {
+      "name": "CBOM Viewer",
+      "publisher": "IBM",
+      "description": "A Web Service to visualize and explore the use of cryptography in software with Cryptography Bills of Materials (CBOM).",
+      "website_url": "https://www.zurich.ibm.com/cbom/",
+      "repository_url": "https://www.zurich.ibm.com/cbom/",
+      "capabilities": [
+        "CBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
+      ],
+      "_fromFile": "cbom_viewer.json"
+    },
+    {
+      "name": "CBOMkit",
+      "publisher": "IBM",
+      "description": "CBOMkit is a toolset for generating, viewing, checking, and storing Cryptography Bills of Materials (CBOM).",
+      "repository_url": "https://github.com/IBM/cbomkit",
+      "website_url": "https://github.com/IBM/cbomkit",
+      "capabilities": [
+        "CBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "PYTHON"
+      ],
+      "_fromFile": "cbomkit.json"
+    },
+    {
+      "name": "CBOMkit-theia",
+      "publisher": "IBM",
+      "description": "A tool that detects cryptographic assets in container images and directories, generating CBOMs.",
+      "repository_url": "https://github.com/IBM/cbomkit-theia",
+      "website_url": "https://github.com/IBM/cbomkit-theia",
+      "capabilities": [
+        "CBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "RESOURCE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "PYTHON"
+      ],
+      "_fromFile": "cbomkit_theia.json"
+    },
+    {
+      "name": "cdx-central",
+      "publisher": "nscuro",
+      "description": "CLI utility that downloads public CycloneDX SBOMs from Maven Central for selected artifacts.",
+      "repository_url": "https://github.com/nscuro/cdx-central",
+      "website_url": "https://github.com/nscuro/cdx-central",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "DISTRIBUTE"
+      ],
+      "analysis": [],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "cdx_central.json"
+    },
+    {
+      "name": "cdx-enrich",
+      "publisher": "Michael Tsfoni",
+      "description": "Enriches a CycloneDX Software Bills of Material (SBOM) with predefined data.",
+      "repository_url": "https://github.com/mtsfoni/cdx-enrich",
+      "website_url": "https://github.com/mtsfoni/cdx-enrich",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "TRANSFORM"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "C#",
+        ".NET"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT",
+        "ERLANG_ELIXIR",
+        "SCALA"
+      ],
+      "_fromFile": "cdx_enrich.json"
+    },
+    {
+      "name": "cdx-vs-cdx",
+      "publisher": "marcosanchotene",
+      "description": "GTK-style Python GUI that compares two CycloneDX JSON SBOMs, highlighting components unique to each file and those present in both.",
+      "repository_url": "https://github.com/marcosanchotene/cdx-vs-cdx",
+      "website_url": "https://github.com/marcosanchotene/cdx-vs-cdx",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "cdx_vs_cdx.json"
+    },
+    {
+      "name": "cdxgen",
+      "publisher": "CycloneDX",
+      "description": "Universal polyglot CLI, library and server that generates CycloneDX SBOMs\u2014including SaaSBOM, OBOM and CBOM variants\u2014for source code, container images and cloud resources.",
+      "repository_url": "https://github.com/CycloneDX/cdxgen",
+      "website_url": "https://cyclonedx.github.io/cdxgen/",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "CBOM",
+        "OBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "SIGNING/NOTARY"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
       ],
       "packaging": [
         "COMMAND_LINE_UTILITY",
@@ -10620,8 +1788,8 @@
         "LIBRARY"
       ],
       "library": [
-        "PYTHON",
-        "OCAML"
+        "JAVASCRIPT_TYPESCRIPT",
+        "NODE.JS"
       ],
       "platform": [
         "LINUX",
@@ -10629,6 +1797,3848 @@
         "WINDOWS"
       ],
       "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "cdxgen.json"
+    },
+    {
+      "name": "Chainloop",
+      "publisher": "Chainloop",
+      "description": "Chainloop is an Open Source evidence store for your Software Supply Chain attestations, SBOMs, VEX, QA reports, and more.",
+      "repository_url": "https://github.com/chainloop-dev/chainloop",
+      "website_url": "https://github.com/chainloop-dev/chainloop",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "SIGNING/NOTARY"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
+      ],
+      "_fromFile": "chainloop.json"
+    },
+    {
+      "name": "Checkov",
+      "publisher": "Checkov",
+      "description": "Prevent cloud misconfigurations during build-time for Terraform, Cloudformation, Kubernetes, Serverless framework and other infrastructure-as-code-languages with Checkov by Bridgecrew. Can output to CycloneDX.",
+      "repository_url": "https://github.com/bridgecrewio/checkov",
+      "website_url": "https://www.checkov.io/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "platform": [
+        "WINDOWS",
+        "LINUX",
+        "MAC"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "PRE-BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "checkov.json"
+    },
+    {
+      "name": "Chelsea",
+      "publisher": "Sonatype",
+      "description": "Dependency vulnerability auditor for Ruby",
+      "repository_url": "https://github.com/sonatype-nexus-community/chelsea",
+      "website_url": "https://github.com/sonatype-nexus-community/chelsea",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "RUBY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "RUBY"
+      ],
+      "_fromFile": "chelsea.json"
+    },
+    {
+      "name": "ClickBOM",
+      "publisher": "ClickHouse",
+      "description": "Downloads and merges SBOMs from various sources. Converts to CycloneDX and SPDX formats. Uploads to cloud storage and ClickHouse for analytics.",
+      "repository_url": "https://github.com/ClickHouse/ClickBOM",
+      "website_url": "https://github.com/marketplace/actions/clickbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE",
+        "TRANSFORM"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "DISCOVERY",
+        "OPERATIONS",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "clickbom.json"
+    },
+    {
+      "name": "CodeNotary CAS",
+      "publisher": "CodeNotary",
+      "description": "CAS is an open source attestation service for the community. Notarize and authorize files, directories, git repos and Build SBOMs of containers.",
+      "repository_url": "https://github.com/codenotary/cas",
+      "website_url": "https://cas.codenotary.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "SIGNING/NOTARY",
+        "AUTHOR"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "codenotary_cas.json"
+    },
+    {
+      "name": "Codenotary CAS Authenticate Docker Image and SBOM",
+      "publisher": "Codenotary",
+      "description": "A GitHub Action which authenticates notarized Docker images and SBOMs.",
+      "repository_url": "https://github.com/codenotary/cas-authenticate-docker-bom-github-action",
+      "website_url": "https://cas.codenotary.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "SIGNING/NOTARY"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "codenotary_cas_authenticate_docker_image_and_sbom.json"
+    },
+    {
+      "name": "Codenotary CAS Notarize Docker Image and SBOM",
+      "publisher": "Codenotary",
+      "description": "A GitHub Action which notarizes and creates an SBOM for Docker images.",
+      "repository_url": "https://github.com/codenotary/cas-notarize-docker-image-bom-github-action",
+      "website_url": "https://cas.codenotary.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "SIGNING/NOTARY",
+        "AUTHOR"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "codenotary_cas_notarize_docker_image_and_sbom.json"
+    },
+    {
+      "name": "Codenotary vcn",
+      "publisher": "Codenotary",
+      "description": "Protects an organization's software development pipeline from supply chain attacks. Codenotary natively supports CycloneDX SBOMs.",
+      "repository_url": "https://github.com/codenotary/vcn",
+      "website_url": "https://codenotary.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "SIGNING/NOTARY"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "codenotary_vcn.json"
+    },
+    {
+      "name": "CodeSentry",
+      "publisher": "GrammaTech",
+      "description": "Software Composition Analysis (SCA) platform that leverages binary analysis to identify components, inherited risk, and communicates inventory through CycloneDX SBOMs",
+      "website_url": "https://www.grammatech.com",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "codesentry.json"
+    },
+    {
+      "name": "Continuous Clearing",
+      "publisher": "Siemens",
+      "description": "Scans third-party OSS components in NPM, NuGet, Maven, Python and Debian projects, generates CycloneDX SBOMs, then uploads them to SW360 and Fossology for automated license clearing.",
+      "repository_url": "https://github.com/siemens/continuous-clearing",
+      "website_url": "https://github.com/siemens/continuous-clearing",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        ".NET"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "PYTHON"
+      ],
+      "_fromFile": "continuous_clearing.json"
+    },
+    {
+      "name": "Contrast Security",
+      "publisher": "Contrast Security",
+      "description": "Automatically generates component inventory from runtime analysis (IAST or RASP) and generates CycloneDX SBOMs",
+      "website_url": "https://www.contrastsecurity.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "RESOURCE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "LIBRARY",
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS",
+        ".NET",
+        "PYTHON",
+        "GO",
+        "PHP",
+        "RUBY"
+      ],
+      "_fromFile": "contrast_security.json"
+    },
+    {
+      "name": "Cosign",
+      "publisher": "Sigstore",
+      "description": "Container Signing, Verification and Storage in an OCI registry, including CycloneDX SBOMs",
+      "repository_url": "https://github.com/sigstore/cosign",
+      "website_url": "https://sigstore.dev/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "SIGNING/NOTARY",
+        "AUTHOR",
+        "DISTRIBUTE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "_fromFile": "cosign.json"
+    },
+    {
+      "name": "Covenant",
+      "publisher": "Patrik Svensson",
+      "description": "Command-line tool that creates SBOMs from .NET and NPM projects or existing CycloneDX BOMs, outputting CycloneDX or SPDX formats.",
+      "repository_url": "https://github.com/patriksvensson/covenant",
+      "website_url": "https://github.com/patriksvensson/covenant",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        ".NET"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "supportedLanguages": [
+        ".NET",
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "_fromFile": "covenant.json"
+    },
+    {
+      "name": "cve-bin-tool",
+      "publisher": "Intel",
+      "description": "Command-line scanner that identifies vulnerable components in binaries, accepts/generates SBOMs, and reports CVEs. Supports 400+ checkers for open source libraries with CycloneDX output.",
+      "repository_url": "https://github.com/intel/cve-bin-tool",
+      "website_url": "https://cve-bin-tool.readthedocs.io/en/latest/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "CPE",
+        "SPDX",
+        "SWID"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "PYTHON",
+        "JAVASCRIPT/TYPESCRIPT",
+        "ERLANG_ELIXIR",
+        "GO",
+        "RUST"
+      ],
+      "_fromFile": "cve_bin_tool.json"
+    },
+    {
+      "name": "CVE Scan",
+      "publisher": "The Embedded Kit",
+      "description": "Detect and mitigate vulnerabilities in embedded systems. Generate SBOMs, cross-reference public databases, integrate with CI pipelines, and use filtering/annotations for streamlined security maintenance.",
+      "website_url": "https://theembeddedkit.io/cve-scan-linux-vulnerability-scanner/",
+      "repository_url": "https://theembeddedkit.io/cve-scan-linux-vulnerability-scanner/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "PYTHON",
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "_fromFile": "cve_scan.json"
+    },
+    {
+      "name": "CxSCA",
+      "publisher": "Checkmarx",
+      "description": "Software Composition Analysis (SCA) platform that identifies vulnerabilities, malicious code, and license risks in open-source libraries with exploitable path analysis and SBOM generation capabilities.",
+      "website_url": "https://checkmarx.com/cxsca-open-source-scanning/",
+      "repository_url": "https://checkmarx.com/cxsca-open-source-scanning/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE",
+        "FREEMIUM"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "cxsca.json"
+    },
+    {
+      "name": "Cybeats SBOM Studio",
+      "publisher": "Cybeats Technologies Inc.",
+      "description": "Enterprise solution to manage SBOMs at scale and proactively discover and reduce risk across the entire software supply chain, from development through deployment.",
+      "repository_url": "https://github.com/cybeats",
+      "website_url": "https://www.cybeats.com/product/sbom-studio",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "TRANSFORM",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "RESOURCE_REPORTING",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "cybeats_sbom_studio.json"
+    },
+    {
+      "name": "Cybellum SBOM",
+      "publisher": "Cybellum Technologies LTD.",
+      "description": "Analyzes binary artifacts to generate SBOMs including context-based analysis to perform accurate vulnerability assessment",
+      "website_url": "https://cybellum.com",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "RESOURCE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "cybellum_sbom.json"
+    },
+    {
+      "name": "Cyberwatch",
+      "publisher": "Cyberwatch",
+      "description": "Cyberwatch Vulnerability Manager allows you to discover assets, scan and prioritize vulnerabilities, and fix them.",
+      "repository_url": "https://cyberwatch.fr/en/",
+      "website_url": "https://cyberwatch.fr/en/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        ".NET",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
+      ],
+      "_fromFile": "cyberwatch.json"
+    },
+    {
+      "name": "CycloneDX-Buildroot",
+      "publisher": "CycloneDX",
+      "description": "Python application that generates CycloneDX Software Bill of Materials (SBOM) for Buildroot-generated projects and other projects with CSV manifest files",
+      "repository_url": "https://github.com/cyclonedx/cyclonedx-buildroot",
+      "website_url": "https://pypi.org/project/cyclonedx-buildroot/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++"
+      ],
+      "_fromFile": "cyclonedx_buildroot.json"
+    },
+    {
+      "name": "CycloneDX CLI",
+      "publisher": "CycloneDX",
+      "description": "CLI tool for SBOM analysis, merging, diffs, format conversions, signing, and validation. Supports CycloneDX XML/JSON/Protobuf/CSV, SPDX JSON, and more.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-cli",
+      "website_url": "https://cyclonedx.org/",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "OBOM",
+        "MBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "TRANSFORM",
+        "SIGNING/NOTARY"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        ".NET"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "cyclonedx_cli.json"
+    },
+    {
+      "name": "CycloneDX Core for Java",
+      "publisher": "OWASP Foundation (CycloneDX Project)",
+      "description": "Java library for creating, parsing, and validating CycloneDX SBOMs.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-core-java",
+      "website_url": "https://cyclonedx.github.io/cyclonedx-core-java/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "JAVA"
+      ],
+      "_fromFile": "cyclonedx_core_for_java.json"
+    },
+    {
+      "name": "cyclonedx_deps_to_mermaid.xsl",
+      "publisher": "Jan Kowalleck",
+      "description": "Extensible Stylesheet Language Transformations (XSLT) to translate CycloneDX dependency graph to mermaid chart.",
+      "repository_url": "https://gist.github.com/jkowalleck/a0f874ee0a8af9a56a0e887631fc53d1",
+      "website_url": "https://gist.github.com/jkowalleck",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "TRANSFORM"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "JAVA",
+        "PHP"
+      ],
+      "_fromFile": "cyclonedx_deps_to_mermaid_xsl.json"
+    },
+    {
+      "name": "cyclonedx-editor-validator",
+      "publisher": "Festo SE & Co. KG",
+      "description": "Command-line utility to create, merge, edit and validate CycloneDX SBOMs and VEX files for automated CI/CD workflows.",
+      "repository_url": "https://github.com/Festo-se/cyclonedx-editor-validator",
+      "website_url": "https://festo-se.github.io/cyclonedx-editor-validator/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "cyclonedx_editor_validator.json"
+    },
+    {
+      "name": "cyclonedx-enrich",
+      "publisher": "fnxpt",
+      "description": "Enrich CycloneDX SBOM files by applying enrichers to improve data quality, including licenses, hashes, properties, and references.",
+      "repository_url": "https://github.com/fnxpt/cyclonedx-enrich",
+      "website_url": "https://github.com/fnxpt/cyclonedx-enrich",
+      "capabilities": [
+        "SBOM",
+        "CBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON",
+        "RUBY"
+      ],
+      "_fromFile": "cyclonedx_enrich.json"
+    },
+    {
+      "name": "CycloneDX for Bower",
+      "publisher": "Hans Thorhauge Dam",
+      "description": "Creates CycloneDX Software Bill of Materials (SBOM) from JavaScript projects that manage dependencies with Bower.",
+      "repository_url": "https://github.com/hanstdam/cdx-bower-bom",
+      "website_url": "https://www.npmjs.com/package/cdx-bower-bom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "cyclonedx_for_bower.json"
+    },
+    {
+      "name": "CycloneDX for Cocoapods",
+      "publisher": "CycloneDX",
+      "description": "Creates CycloneDX SBOMs for Objective-C and Swift projects that use CocoaPods.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-cocoapods",
+      "website_url": "https://github.com/CycloneDX/cyclonedx-cocoapods",
+      "capabilities": [
+        "SBOM",
+        "OBOM",
+        "MBOM",
+        "SAASBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "RUBY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "SWIFT"
+      ],
+      "_fromFile": "cyclonedx_for_cocoapods.json"
+    },
+    {
+      "name": "CycloneDX for Conan1",
+      "publisher": "CycloneDX",
+      "description": "Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects using Conan1 (note: considered deprecated)",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-conan",
+      "website_url": "https://pypi.org/project/cyclonedx-conan/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "platform": [
+        "WINDOWS",
+        "LINUX",
+        "MAC"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "supportedLanguages": [
+        "C/C++"
+      ],
+      "_fromFile": "cyclonedx_for_conan1.json"
+    },
+    {
+      "name": "CycloneDX for Conan2",
+      "publisher": "Conan-IO",
+      "description": "Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects using Conan2",
+      "repository_url": "https://github.com/conan-io/conan-extensions",
+      "website_url": "https://github.com/conan-io/conan-extensions/tree/main/extensions/commands/sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "packaging": [
+        "CONAN_EXTENSION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "platform": [
+        "WINDOWS",
+        "LINUX",
+        "MAC"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.1",
+        "CYCLONEDX_V1.0"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "supportedLanguages": [
+        "C/C++"
+      ],
+      "_fromFile": "cyclonedx_for_conan2.json"
+    },
+    {
+      "name": "CycloneDX for Erlang/Elixir (Mix)",
+      "publisher": "Bram Verburg",
+      "description": "Mix task that generates CycloneDX SBOMs for Erlang/Elixir projects, exporting XML or JSON and supporting multiple CycloneDX schema versions.",
+      "repository_url": "https://github.com/voltone/sbom",
+      "website_url": "https://hex.pm/packages/sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "ERLANG_ELIXIR"
+      ],
+      "library": [
+        "ERLANG_ELIXIR"
+      ],
+      "_fromFile": "cyclonedx_for_erlang_elixir_mix_.json"
+    },
+    {
+      "name": "CycloneDX for Erlang/Elixir (Rebar3)",
+      "publisher": "Bram Verburg",
+      "description": "Rebar3 plug-in that generates CycloneDX SBOMs for Erlang/Elixir projects, exporting XML or JSON and supporting CycloneDX v1.4.",
+      "repository_url": "https://github.com/voltone/rebar3_sbom",
+      "website_url": "https://hex.pm/packages/rebar3_sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "ERLANG_ELIXIR"
+      ],
+      "library": [
+        "ERLANG_ELIXIR"
+      ],
+      "_fromFile": "cyclonedx_for_erlang_elixir_rebar3_.json"
+    },
+    {
+      "name": "CycloneDX for Go",
+      "publisher": "Ozon",
+      "description": "Command-line utility and Go library that generates CycloneDX SBOMs from Go module projects for supply-chain transparency.",
+      "repository_url": "https://github.com/ozonru/cyclonedx-go",
+      "website_url": "https://github.com/ozonru/cyclonedx-go",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "cyclonedx_for_go.json"
+    },
+    {
+      "name": "CycloneDX for Go modules",
+      "publisher": "OWASP Foundation \u2013 CycloneDX Project",
+      "description": "Command-line utility and Go library that generates CycloneDX SBOMs from Go modules, binaries and applications.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-gomod",
+      "website_url": "https://github.com/CycloneDX/cyclonedx-gomod",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "cyclonedx_for_go_modules.json"
+    },
+    {
+      "name": "CycloneDX for Gradle",
+      "publisher": "CycloneDX",
+      "description": "Gradle plugin that generates CycloneDX SBOMs (XML or JSON) for all dependencies in Java-based builds.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-gradle-plugin",
+      "website_url": "https://plugins.gradle.org/plugin/org.cyclonedx.bom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "JAVA"
+      ],
+      "_fromFile": "cyclonedx_for_gradle.json"
+    },
+    {
+      "name": "CycloneDX for Maven",
+      "publisher": "OWASP Foundation / CycloneDX Project",
+      "description": "Apache Maven plugin that automatically generates CycloneDX SBOMs (JSON or XML) for Java projects and can attach vulnerability disclosure information.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-maven-plugin",
+      "website_url": "https://github.com/CycloneDX/cyclonedx-maven-plugin",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "CPE"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "JAVA"
+      ],
+      "_fromFile": "cyclonedx_for_maven.json"
+    },
+    {
+      "name": "CycloneDX for .NET",
+      "publisher": "CycloneDX",
+      "description": "Generates CycloneDX Software Bill of Materials (SBOM) from .NET projects.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-dotnet",
+      "website_url": "https://www.nuget.org/packages/CycloneDX/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        ".NET"
+      ],
+      "_fromFile": "cyclonedx_for_net.json"
+    },
+    {
+      "name": "CycloneDX for Node.js",
+      "publisher": "OWASP Foundation (CycloneDX Project)",
+      "description": "This is a so-called meta-package, it does not ship any own functionality, but it is a collection of optional dependencies with one purpose in common: generate CycloneDX Software-Bill-of-Materials (SBOM) from node-based projects.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-node-module",
+      "website_url": "https://www.npmjs.com/package/@cyclonedx/bom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "NODE.JS"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "_fromFile": "cyclonedx_for_node_js.json"
+    },
+    {
+      "name": "CycloneDX for NPM",
+      "publisher": "CycloneDX",
+      "description": "Create CycloneDX Software Bill of Materials (SBOM) from npm projects.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-node-npm",
+      "website_url": "https://www.npmjs.com/package/@cyclonedx/cyclonedx-npm",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DESIGN",
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "_fromFile": "cyclonedx_for_npm.json"
+    },
+    {
+      "name": "CycloneDX for PHP Composer",
+      "publisher": "CycloneDX",
+      "description": "Create CycloneDX Software Bill of Materials (SBOM) from PHP Composer projects.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-php-composer",
+      "website_url": "https://packagist.org/packages/cyclonedx/cyclonedx-php-composer",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMPOSER_PLUGIN",
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.1"
+      ],
+      "library": [
+        "PHP"
+      ],
+      "supportedLanguages": [
+        "PHP"
+      ],
+      "_fromFile": "cyclonedx_for_php_composer.json"
+    },
+    {
+      "name": "CycloneDX for Python",
+      "publisher": "CycloneDX",
+      "description": "Generates CycloneDX SBOMs from Python (virtual) environments, requirement files, and manifests (Poetry, PipEnv, etc)",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-python",
+      "website_url": "https://pypi.org/project/cyclonedx-bom/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.1",
+        "CYCLONEDX_V1.0"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "cyclonedx_for_python.json"
+    },
+    {
+      "name": "CycloneDX for Ruby Gems",
+      "publisher": "OWASP Foundation",
+      "description": "Command-line utility and Ruby library that generates CycloneDX SBOMs for Ruby projects by analysing Gem dependencies.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-ruby-gem",
+      "website_url": "https://rubygems.org/gems/cyclonedx-ruby",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "RUBY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "RUBY"
+      ],
+      "_fromFile": "cyclonedx_for_ruby_gems.json"
+    },
+    {
+      "name": "CycloneDX for Rust Cargo",
+      "publisher": "CycloneDX Project (OWASP)",
+      "description": "Cargo sub-command and CLI library that generates CycloneDX SBOMs for Rust projects, aggregating all crate dependencies and outputting JSON or XML.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-rust-cargo",
+      "website_url": "https://crates.io/crates/cyclonedx-bom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "RUST"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "RUST"
+      ],
+      "_fromFile": "cyclonedx_for_rust_cargo.json"
+    },
+    {
+      "name": "CycloneDX for SBT (Scala)",
+      "publisher": "Fabrizio Di Giuseppe",
+      "description": "SBT plugin that generates CycloneDX SBOMs (JSON or XML) for Scala/Java builds, supporting schema v1.6 and integrating smoothly with Dependency-Track.",
+      "repository_url": "https://github.com/sbt/sbt-sbom",
+      "website_url": "https://github.com/sbt/sbt-sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "SCALA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "SCALA"
+      ],
+      "_fromFile": "cyclonedx_for_sbt_scala_.json"
+    },
+    {
+      "name": "CycloneDX for Webpack",
+      "publisher": "OWASP Foundation",
+      "description": "Webpack plugin that generates CycloneDX Software Bill of Materials (SBOM) for JavaScript/TypeScript bundles during the build process.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin",
+      "website_url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "WEBPACK_PLUGIN"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "_fromFile": "cyclonedx_for_webpack.json"
+    },
+    {
+      "name": "CycloneDX for Yarn",
+      "publisher": "CycloneDX",
+      "description": "Create CycloneDX Software Bill of Materials (SBOM) from yarn projects.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-node-yarn",
+      "website_url": "https://classic.yarnpkg.com/en/package/@cyclonedx/yarn-plugin-cyclonedx",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "YARN_PLUGIN",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "supportedLanguages": [
+        "NODE.JS",
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "cyclonedx_for_yarn.json"
+    },
+    {
+      "name": "CycloneDX GoMod Generate SBOM",
+      "publisher": "CycloneDX",
+      "description": "GitHub action which generates CycloneDX SBOMs from Go modules, providing integration into CI/CD workflows for Go projects.",
+      "repository_url": "https://github.com/CycloneDX/gh-gomod-generate-sbom",
+      "website_url": "https://github.com/marketplace/actions/cyclonedx-gomod-generate-sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "cyclonedx_gomod_generate_sbom.json"
+    },
+    {
+      "name": "CycloneDX JavaScript Library",
+      "publisher": "CycloneDX",
+      "description": "Core functionality of CycloneDX for JavaScript (Node.js or Web Browser) written in TypeScript.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-javascript-library",
+      "website_url": "https://www.npmjs.com/package/@cyclonedx/cyclonedx-library",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "OBOM",
+        "MBOM",
+        "HBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "SWID"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "_fromFile": "cyclonedx_javascript_library.json"
+    },
+    {
+      "name": "CycloneDX Libraries for .NET",
+      "publisher": "CycloneDX",
+      "description": ".NET libraries to consume and produce CycloneDX Software Bill of Materials (SBOM).",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-dotnet-library",
+      "website_url": "https://www.nuget.org/profiles/CycloneDX",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "OBOM",
+        "MBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        ".NET"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DESIGN",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "SWID"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        ".NET"
+      ],
+      "_fromFile": "cyclonedx_libraries_for_net.json"
+    },
+    {
+      "name": "CycloneDX library for Go",
+      "publisher": "CycloneDX",
+      "description": "Go library that can parse, create and serialize CycloneDX Software Bill of Materials (SBOM) in JSON or XML.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-go",
+      "website_url": "https://github.com/CycloneDX/cyclonedx-go",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DESIGN",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "cyclonedx_library_for_go.json"
+    },
+    {
+      "name": "cyclonedx-merge",
+      "publisher": "fnxpt",
+      "description": "Tool to merge CycloneDX files (JSON/XML) with support for normal, flat, and smart merge modes.",
+      "repository_url": "https://github.com/fnxpt/cyclonedx-merge",
+      "website_url": "https://github.com/fnxpt/cyclonedx-merge",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "TRANSFORM"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "cyclonedx_merge.json"
+    },
+    {
+      "name": "CycloneDX .NET Generate SBOM",
+      "publisher": "CycloneDX",
+      "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for .NET projects supporting multiple project formats and recursive analysis",
+      "repository_url": "https://github.com/CycloneDX/gh-dotnet-generate-sbom",
+      "website_url": "https://github.com/marketplace/actions/cyclonedx-dotnet-generate-sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        ".NET"
+      ],
+      "_fromFile": "cyclonedx_net_generate_sbom.json"
+    },
+    {
+      "name": "CycloneDX Node.js Generate SBOM",
+      "publisher": "CycloneDX",
+      "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for Node.js projects containing an aggregate of all project dependencies. (note: considered deprecated)",
+      "repository_url": "https://github.com/CycloneDX/gh-node-module-generatebom",
+      "website_url": "https://github.com/marketplace/actions/cyclonedx-node-js-generate-sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "NODE.JS",
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "cyclonedx_node_js_generate_sbom.json"
+    },
+    {
+      "name": "cyclonedx-npm-pipe",
+      "publisher": "ShiftLeftCyber",
+      "description": "Bitbucket Pipe that packages cdxgen in a Docker image to generate CycloneDX v1.6 SBOMs for Node.js/npm projects in CI pipelines.",
+      "repository_url": "https://github.com/ccideas/cyclonedx-npm-pipe",
+      "website_url": "https://shiftleftcyber.io",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "SHELL"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "NODE.JS"
+      ],
+      "_fromFile": "cyclonedx_npm_pipe.json"
+    },
+    {
+      "name": "CycloneDX Perl Library",
+      "publisher": "Giuseppe Di Terlizzi",
+      "description": "Perl library for generating CycloneDX SBOMs.",
+      "repository_url": "https://github.com/giterlizzi/perl-SBOM-CycloneDX",
+      "website_url": "https://github.com/giterlizzi/perl-SBOM-CycloneDX",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "PERL"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "PERL"
+      ],
+      "_fromFile": "cyclonedx_perl_library.json"
+    },
+    {
+      "name": "CycloneDX PHP Composer Generate SBOM",
+      "publisher": "CycloneDX",
+      "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for PHP Composer projects (note: considered deprecated)",
+      "repository_url": "https://github.com/CycloneDX/gh-php-composer-generate-sbom",
+      "website_url": "https://github.com/marketplace/actions/cyclonedx-php-composer-generate-sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "PHP"
+      ],
+      "_fromFile": "cyclonedx_php_composer_generate_sbom.json"
+    },
+    {
+      "name": "CycloneDX PHP Library",
+      "publisher": "CycloneDX",
+      "description": "PHP library that supplies data-models, serializers, validators and utilities for creating, parsing and validating CycloneDX BOM documents in JSON and XML formats.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-php-library",
+      "website_url": "https://packagist.org/packages/cyclonedx/cyclonedx-library",
+      "capabilities": [
+        "SBOM",
+        "HBOM",
+        "OBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "PHP"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.1"
+      ],
+      "supportedLanguages": [
+        "PHP"
+      ],
+      "_fromFile": "cyclonedx_php_library.json"
+    },
+    {
+      "name": "CycloneDX Python Generate SBOM",
+      "publisher": "CycloneDX",
+      "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for Python projects from requirements files (note: considered deprecated)",
+      "repository_url": "https://github.com/CycloneDX/gh-python-generate-sbom",
+      "website_url": "https://github.com/marketplace/actions/cyclonedx-python-generate-sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "cyclonedx_python_generate_sbom.json"
+    },
+    {
+      "name": "CycloneDX Python Library",
+      "publisher": "CycloneDX",
+      "description": "This Python package provides data models, validators and more, to help you create/render/read CycloneDX documents.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-python-lib",
+      "website_url": "https://pypi.org/project/cyclonedx-python-lib/",
+      "capabilities": [
+        "SBOM",
+        "CBOM",
+        "MBOM",
+        "OBOM",
+        "SAASBOM",
+        "RELEASE_NOTES",
+        "VDR/VEX",
+        "CDXA",
+        "HBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "SWID"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.1",
+        "CYCLONEDX_V1.0"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "cyclonedx_python_library.json"
+    },
+    {
+      "name": "CycloneDX Rust",
+      "publisher": "Mark Dodgson",
+      "description": "Simple Rust library to encode and decode CycloneDX BOMs.",
+      "repository_url": "https://github.com/doddi/cyclonedx-rust",
+      "website_url": "https://github.com/doddi/cyclonedx-rust",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "RUST"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "cyclonedx_rust.json"
+    },
+    {
+      "name": "CycloneDX Web Tool",
+      "publisher": "CycloneDX",
+      "description": "Web-based tool for validating, viewing, and converting CycloneDX SBOMs. Supports XML/JSON, and conversion between CycloneDX and SPDX formats.",
+      "repository_url": "https://github.com/CycloneDX/cyclonedx-web-tool",
+      "website_url": "https://cyclonedx.github.io/cyclonedx-web-tool/",
+      "capabilities": [
+        "SBOM",
+        "OBOM",
+        "MBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "TRANSFORM",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.1",
+        "CYCLONEDX_V1.0"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "cyclonedx_web_tool.json"
+    },
+    {
+      "name": "DaggerBoard",
+      "publisher": "NewYork-Presbyterian Hospital",
+      "description": "Vulnerability-scanning application that ingests CycloneDX or SPDX SBOM files, analyses listed dependencies for known CVEs, and presents results through a web dashboard.",
+      "repository_url": "https://github.com/nyph-infosec/daggerboard",
+      "website_url": "https://github.com/nyph-infosec/daggerboard",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "PYTHON",
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "daggerboard.json"
+    },
+    {
+      "name": "Debricked",
+      "publisher": "OpenText",
+      "description": "Debricked lets teams automatically find, fix and prevent open-source vulnerabilities, avoid non-compliant licences and pick healthier dependencies, with CycloneDX SBOM import/export, CLI and SaaS dashboards.",
+      "repository_url": "https://github.com/debricked/cli",
+      "website_url": "https://debricked.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "FREEMIUM"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DESIGN",
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "PHP",
+        "PYTHON",
+        "RUBY"
+      ],
+      "_fromFile": "debricked.json"
+    },
+    {
+      "name": "Defect Dojo",
+      "publisher": "OWASP",
+      "description": "Open source vulnerability management and automation platform that can import CycloneDX SBOMs and over 190 security tool reports for centralized vulnerability tracking and analysis.",
+      "repository_url": "https://github.com/DefectDojo/django-DefectDojo",
+      "website_url": "https://www.defectdojo.org/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "defect_dojo.json"
+    },
+    {
+      "name": "Dependency-Track",
+      "publisher": "OWASP",
+      "description": "An intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain by leveraging SBOMs",
+      "repository_url": "https://github.com/DependencyTrack/dependency-track",
+      "website_url": "https://dependencytrack.org/",
+      "capabilities": [
+        "HBOM",
+        "OBOM",
+        "SAASBOM",
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "CONTAINER_IMAGE",
+        "APPLICATION"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "CPE",
+        "SWID"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON",
+        "RUBY",
+        "PHP",
+        "RUST",
+        "C/C++",
+        ".NET",
+        "PERL",
+        "ERLANG_ELIXIR"
+      ],
+      "_fromFile": "dependency_track.json"
+    },
+    {
+      "name": "Dependency-Track Jenkins Plugin",
+      "publisher": "OWASP",
+      "description": "Jenkins plugin that publishes CycloneDX Software Bill-of-Materials (SBOM) to the Dependency-Track platform for vulnerability analysis and policy evaluation",
+      "repository_url": "https://github.com/jenkinsci/dependency-track-plugin",
+      "website_url": "https://plugins.jenkins.io/dependency-track/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "JENKINS_PLUGIN"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "dependency_track_jenkins_plugin.json"
+    },
+    {
+      "name": "Dependency-Track Maven Plugin",
+      "publisher": "Paul McKeown",
+      "description": "Maven plugin that integrates with a Dependency-Track server to submit SBOMs and optionally fail execution when vulnerable dependencies are found",
+      "repository_url": "https://github.com/pmckeown/dependency-track-maven-plugin",
+      "website_url": "https://github.com/pmckeown/dependency-track-maven-plugin#readme",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "MAVEN_PLUGIN"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "JAVA"
+      ],
+      "_fromFile": "dependency_track_maven_plugin.json"
+    },
+    {
+      "name": "Distro2SBOM",
+      "publisher": "Anthony Harrison",
+      "description": "A command line tool which creates CycloneDX and SPDX SBOMs for an installed application or distribution (Debian, RPM, Windows and FreeBSD systems supported).",
+      "repository_url": "https://github.com/anthonyharrison/distro2sbom",
+      "website_url": "https://pypi.org/project/distro2sbom/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "TRANSFORM",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "transform": [
+        "BOM_STANDARD"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "_fromFile": "distro2sbom.json"
+    },
+    {
+      "name": "docker-sbom-cli-plugin",
+      "publisher": "Docker",
+      "description": "Docker CLI plugin that generates Software Bills of Materials (SBOMs) for container images using Syft as the underlying scanner, with CycloneDX output support.",
+      "repository_url": "https://github.com/docker/sbom-cli-plugin",
+      "website_url": "https://github.com/docker/sbom-cli-plugin",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO",
+        "SHELL"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "docker_sbom_cli_plugin.json"
+    },
+    {
+      "name": "dtrack-audit",
+      "publisher": "OZON",
+      "description": "Command-line client for OWASP Dependency-Track that publishes SBOMs and displays vulnerability information from the command line, designed for CI/CD integration",
+      "repository_url": "https://github.com/ozontech/dtrack-audit",
+      "website_url": "https://github.com/ozontech/dtrack-audit",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "dtrack_audit.json"
+    },
+    {
+      "name": "DtrackAuditor",
+      "publisher": "Thinksabin",
+      "description": "Python CLI tool to upload CycloneDX SBOMs to Dependency-Track, analyze vulnerabilities, enforce policy, and fail CI builds based on thresholds.",
+      "repository_url": "https://github.com/thinksabin/DTrackAuditor",
+      "website_url": "https://github.com/thinksabin/DTrackAuditor",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "dtrackauditor.json"
+    },
+    {
+      "name": "Eclipse SW360 Antenna",
+      "publisher": "Eclipse Foundation",
+      "description": "Archived tool that scanned project artifacts, downloaded sources for dependencies, validated licenses, and generated license compliance documentation",
+      "repository_url": "https://github.com/eclipse-archived/antenna",
+      "website_url": "https://www.eclipse.org/sw360/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING",
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "JAVA"
+      ],
+      "_fromFile": "eclipse_sw360_antenna.json"
+    },
+    {
+      "name": "EMBA",
+      "publisher": "EMBA Project",
+      "description": "EMBA is an open-source firmware security analyzer that extracts firmware, performs static and dynamic analysis, builds CycloneDX SBOMs with VEX data, and generates detailed vulnerability reports.",
+      "repository_url": "https://github.com/e-m-b-a/emba",
+      "website_url": "https://www.securefirmware.de",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "SHELL",
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "emba.json"
+    },
+    {
+      "name": "Endor Labs",
+      "publisher": "Endor Labs",
+      "description": "Cloud-native platform that auto-creates CycloneDX SBOMs, generates VEX, and analyzes reachability so teams can securely select, integrate and maintain open-source software at scale.",
+      "website_url": "https://endorlabs.com",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "GITHUB_ACTION",
+        "GITLAB_CI_TEMPLATE"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY"
+      ],
+      "_fromFile": "endor_labs.json"
+    },
+    {
+      "name": "Enso",
+      "publisher": "Enso Security",
+      "description": "Application Security Posture Management (ASPM) platform that inventories software assets, tracks AppSec tools and processes, and outputs CycloneDX and SPDX SBOMs with optional VEX ingest.",
+      "website_url": "https://www.enso.security",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DISCOVERY",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "enso.json"
+    },
+    {
+      "name": "EXPLIoT IoT Security Assessment Framework",
+      "publisher": "EXPLIoT",
+      "description": "EXPLIoT is an AGPLv3 Python framework and CLI for assessing and exploiting IoT devices; it offers 140+ plug-ins and can generate CycloneDX SBOMs from firmware filesystems.",
+      "repository_url": "https://gitlab.com/expliot_framework/expliot",
+      "website_url": "https://expliot.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "expliot_iot_security_assessment_framework.json"
+    },
+    {
+      "name": "FACT",
+      "publisher": "aDolus Technology Inc.",
+      "description": "The aDolus FACT platform is an advanced aggregation, analytics, and correlation engine that generates NTIA-compliant SBOMs (including CycloneDX) and provides continuous cybersecurity risk intelligence across the software supply chain.",
+      "website_url": "https://adolus.com",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "lifecycle": [
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "SWID"
+      ],
+      "_fromFile": "fact.json"
+    },
+    {
+      "name": "Flawnter",
+      "publisher": "CyberTest",
+      "description": "Flawnter is a zero-trust static, dynamic and composition analysis platform that detects code flaws, vulnerabilities and license risks, and generates CycloneDX/SPDX SBOMs during every scan.",
+      "website_url": "https://www.flawnter.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "FREEMIUM",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "C/C++",
+        ".NET",
+        "JAVA",
+        "KOTLIN",
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "GO",
+        "RUBY",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "flawnter.json"
+    },
+    {
+      "name": "Fortify on Demand",
+      "publisher": "Micro Focus",
+      "description": "SaaS application-security testing platform offering SAST, DAST and SCA. Produces and consumes CycloneDX SBOMs to secure the software supply chain across many languages, frameworks and package managers.",
+      "repository_url": "https://github.com/fortify/github-action",
+      "website_url": "https://www.microfocus.com/en-us/cyberres/application-security/fortify-on-demand",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
         "BUILD",
         "POST-BUILD",
         "OPERATIONS"
@@ -10649,13 +5659,4425 @@
         "PHP",
         "PYTHON",
         "RUBY",
+        "SCALA",
+        "KOTLIN",
+        "SWIFT"
+      ],
+      "_fromFile": "fortify_on_demand.json"
+    },
+    {
+      "name": "Fortify Software Security Center",
+      "publisher": "Micro Focus",
+      "description": "Open-source CycloneDX parser plugin for Fortify SSC that imports SBOMs, correlates components with known vulnerabilities and licenses, and displays them in the SSC portal.",
+      "repository_url": "https://github.com/fortify/fortify-ssc-parser-generic-cyclonedx",
+      "website_url": "https://github.com/fortify/fortify-ssc-parser-generic-cyclonedx",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "TRANSFORM",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "CPE",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY"
+      ],
+      "_fromFile": "fortify_software_security_center.json"
+    },
+    {
+      "name": "Fortress Asset 2 Vendor",
+      "publisher": "Fortress Information Security",
+      "description": "Comprehensive cyber supply chain risk management platform that ingests, analyzes and securely shares SBOMs, HBOMs and other supply chain attestations via SaaS and permissioned blockchain.",
+      "website_url": "https://assettovendor.com/",
+      "repository_url": "https://assettovendor.com",
+      "capabilities": [
+        "SBOM",
+        "HBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "DISTRIBUTE",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "fortress_asset_2_vendor.json"
+    },
+    {
+      "name": "Fortress File Integrity Assurance",
+      "publisher": "Fortress Information Security",
+      "description": "A proprietary software analysis tool that validates patches and ensures software file integrity to enhance software supply chain security in critical infrastructure environments.",
+      "website_url": "https://www.fortressinfosec.com/",
+      "repository_url": "https://www.fortressinfosec.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "fortress_file_integrity_assurance.json"
+    },
+    {
+      "name": "FOSSA",
+      "publisher": "FOSSA",
+      "description": "Subscription SCA platform and CLI that generate, import, analyse, and distribute CycloneDX or SPDX SBOMs for licence and vulnerability risk management across CI/CD pipelines.",
+      "repository_url": "https://github.com/fossas/fossa-cli",
+      "website_url": "https://fossa.com",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [
+        "BOM_STANDARD"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "fossa.json"
+    },
+    {
+      "name": "Gemnasium",
+      "publisher": "GitLab",
+      "description": "Dependency scanning analyzer that uses the GitLab Advisory Database to detect vulnerabilities in project dependencies and generates CycloneDX SBOMs.",
+      "repository_url": "https://gitlab.com/gitlab-org/security-products/analyzers/gemnasium",
+      "website_url": "https://docs.gitlab.com/ee/user/application_security/dependency_scanning/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE",
+        "FREEMIUM"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "CONTAINER_IMAGE",
+        "GITLAB_CI_TEMPLATE"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "RUBY",
+        "PYTHON",
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS",
+        "JAVA",
+        "GO",
+        "PHP"
+      ],
+      "_fromFile": "gemnasium.json"
+    },
+    {
+      "name": "Generate SBoM for Elixir project",
+      "publisher": "Red Shirts",
+      "description": "GitHub Action to generate CycloneDX Software Bill-of-Materials (SBOM) for Erlang/Elixir Mix projects",
+      "repository_url": "https://github.com/red-shirts/action-mix-sbom",
+      "website_url": "https://github.com/marketplace/actions/generate-sbom-for-elixir-project",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [],
+      "transform": [],
+      "packaging": [
+        "GITHUB_ACTION",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "ERLANG_ELIXIR"
+      ],
+      "_fromFile": "generate_sbom_for_elixir_project.json"
+    },
+    {
+      "name": "gh-sbom",
+      "publisher": "GitHub",
+      "description": "CLI extension for the gh tool that generates CycloneDX or SPDX JSON SBOMs for any GitHub repository using Dependency Graph data.",
+      "repository_url": "https://github.com/advanced-security/gh-sbom",
+      "website_url": "https://github.com/advanced-security/gh-sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "gh_sbom.json"
+    },
+    {
+      "name": "Go Sonatypes",
+      "publisher": "Sonatype",
+      "description": "Common utility packages for working with OSS Index, Nexus IQ Server, CycloneDX SBOMs or getting a user-agent",
+      "repository_url": "https://github.com/sonatype-nexus-community/go-sona-types",
+      "website_url": "https://github.com/sonatype-nexus-community/go-sona-types",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "go_sonatypes.json"
+    },
+    {
+      "name": "gobom",
+      "publisher": "Mattermost",
+      "description": "An extensible CycloneDX BOM generator and Dependency-Track API client written in Go; supports Go, npm, CocoaPods and Gradle projects and uploads SBOMs for analysis.",
+      "repository_url": "https://github.com/mattermost/gobom",
+      "website_url": "https://github.com/mattermost/gobom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVASCRIPT/TYPESCRIPT",
+        "JAVA",
+        "SWIFT"
+      ],
+      "_fromFile": "gobom.json"
+    },
+    {
+      "name": "Grype",
+      "publisher": "Anchore",
+      "description": "A vulnerability scanner for container images and filesystems. Works with Syft SBOMs and supports CycloneDX, SPDX, and OpenVEX.",
+      "repository_url": "https://github.com/anchore/grype",
+      "website_url": "https://github.com/anchore/grype",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC"
+      ],
+      "lifecycle": [
+        "DISCOVERY",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL",
+        "CPE"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "grype.json"
+    },
+    {
+      "name": "Heimdall",
+      "publisher": "MedCrypt",
+      "description": "Automatically extract or manually upload your Software Bill of Materials (SBOM), and Heimdall will, on a continual basis, identify known vulnerabilities affecting your software components",
+      "website_url": "https://www.medcrypt.com/solutions/helm",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "RESOURCE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "heimdall.json"
+    },
+    {
+      "name": "Hermeto",
+      "publisher": "The Hermeto Project",
+      "description": "Hermeto is a CLI tool that pre-fetches your project's dependencies, which enables network-isolated builds, which enables the production of high-accuracy SBOMs",
+      "repository_url": "https://github.com/hermetoproject/hermeto",
+      "website_url": "https://hermetoproject.github.io/hermeto/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "SLSA",
+        "PACKAGE_URL"
+      ],
+      "supportedLanguages": [
+        "RUBY",
+        "RUST",
+        "GO",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
+      ],
+      "_fromFile": "hermeto.json"
+    },
+    {
+      "name": "Ion Channel Platform",
+      "publisher": "Ion Channel",
+      "description": "Risk management platform that enables analysis, exchange and continuous monitoring of Software Bills of Materials (SBOMs) to actively manage third party risk and compliance",
+      "website_url": "https://www.exiger.com/products/ion-channel/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "ion_channel_platform.json"
+    },
+    {
+      "name": "ittosai",
+      "publisher": "DevOps KungFu Masters",
+      "description": "ittosai is a CycloneDX SBOM vulnerability analyzer that analyzes SBOMs every time a developer commits code to a repository.",
+      "repository_url": "https://github.com/devops-kung-fu/ittosai",
+      "website_url": "https://dkfm.io/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "ittosai.json"
+    },
+    {
+      "name": "Jake",
+      "publisher": "Sonatype",
+      "description": "An OSS Index integration to check your Conda environments for vulnerable Open Source packages",
+      "repository_url": "https://github.com/sonatype-nexus-community/jake",
+      "website_url": "https://jake.readthedocs.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "jake.json"
+    },
+    {
+      "name": "jbom",
+      "publisher": "Eclipse Foundation (originally Contrast Security)",
+      "description": "jbom generates runtime and static CycloneDX SBOMs for local or remote Java applications and archives.",
+      "repository_url": "https://github.com/eclipse/jbom",
+      "website_url": "https://projects.eclipse.org/projects/technology.jbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "JAVA"
+      ],
+      "_fromFile": "jbom.json"
+    },
+    {
+      "name": "JDisc Discovery",
+      "publisher": "JDisc",
+      "description": "Network discovery and IT inventory tool that can discover CycloneDX SBOMs on enterprise assets and ingest component inventory into the platform.",
+      "website_url": "https://www.jdisc.com/",
+      "repository_url": "https://www.jdisc.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "RESOURCE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DISCOVERY",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "jdisc_discovery.json"
+    },
+    {
+      "name": "Jetstack Secure",
+      "publisher": "Jetstack",
+      "description": "Manages machine identities across Cloud Native Kubernetes and OpenShift environments, providing a detailed view of enterprise security posture for TLS certificates and PKI.",
+      "repository_url": "https://github.com/jetstack/jetstack-secure",
+      "website_url": "https://www.jetstack.io/jetstack-secure/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "CONTAINER_IMAGE",
+        "APPLICATION"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "jetstack_secure.json"
+    },
+    {
+      "name": "JupiterOne",
+      "publisher": "JupiterOne",
+      "description": "Easily identify, map, analyze, and secure cyber assets and attack surface. Gain full visibility into complex cloud environments to uncover threats, close compliance gaps, and prioritize risk.",
+      "website_url": "https://jupiterone.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "RESOURCE_REPORTING",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "WINDOWS",
+        "MAC",
+        "LINUX"
+      ],
+      "lifecycle": [
+        "DISCOVERY",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "jupiterone.json"
+    },
+    {
+      "name": "kbom - Kubernetes Bill of Materials powered by KSOC",
+      "publisher": "KSOC",
+      "description": "kbom is an open-source CLI tool from KSOC, written in Go, that generates detailed CycloneDX SBOMs for Kubernetes clusters, including nodes, control plane, OS, and cloud infrastructure details.",
+      "repository_url": "https://github.com/rad-security/kbom",
+      "website_url": "https://github.com/rad-security/kbom",
+      "capabilities": [
+        "SBOM",
+        "OBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "RESOURCE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "_fromFile": "kbom_kubernetes_bill_of_materials_powered_by_ksoc.json"
+    },
+    {
+      "name": "Keysight IoT Security Assessment",
+      "publisher": "Keysight",
+      "description": "Automated firmware analysis platform that generates SBOMs and identifies vulnerabilities, misconfigurations, hardcoded credentials, weak cryptography, and potential zero-day vulnerabilities in IoT devices.",
+      "website_url": "https://www.keysight.com/be/en/products/network-security/iot-security-assessment.html",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "DISCOVERY",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "keysight_iot_security_assessment.json"
+    },
+    {
+      "name": "KICS",
+      "publisher": "Checkmarx",
+      "description": "KICS scans Infrastructure-as-Code to detect security vulnerabilities, compliance issues and misconfigurations, exporting results as CycloneDX SBOM and VDR reports.",
+      "repository_url": "https://github.com/Checkmarx/kics",
+      "website_url": "https://www.kics.io/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "AZURE_PIPELINE_EXTENSION"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.3"
+      ],
+      "_fromFile": "kics.json"
+    },
+    {
+      "name": "Ko",
+      "publisher": "Ko Build",
+      "description": "Simple, fast container image builder for Go applications that generates CycloneDX SBOMs by default, supports multi-platform builds, and integrates seamlessly with Kubernetes.",
+      "repository_url": "https://github.com/ko-build/ko",
+      "website_url": "https://ko.build/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "ko.json"
+    },
+    {
+      "name": "Kondukto",
+      "publisher": "Kondukto",
+      "description": "Application Security Orchestration and Correlation platform that generates and consumes CycloneDX or SPDX SBOMs, correlates vulnerability scanner findings, and automates remediation workflows across CI/CD pipelines.",
+      "website_url": "https://kondukto.io",
+      "repository_url": "https://github.com/kondukto-io/kdt",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_STANDARD"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "kondukto.json"
+    },
+    {
+      "name": "KubeClarity",
+      "publisher": "Cisco",
+      "description": "Open-source platform (CLI, UI & Helm chart) that generates SBOMs, converts them between CycloneDX/SPDX formats, and scans container images, directories and running Kubernetes clusters for vulnerabilities, licences and CIS Docker benchmark findings.",
+      "repository_url": "https://github.com/openclarity/kubeclarity",
+      "website_url": "https://github.com/cisco-open/kubei",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "APPLICATION"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "kubeclarity.json"
+    },
+    {
+      "name": "Kyverno",
+      "publisher": "Kyverno Project (CNCF Incubating)",
+      "description": "Kyverno is an open-source Kubernetes policy engine that validates, mutates and generates configurations, and can evaluate CycloneDX SBOM attestations to enforce supply-chain policies.",
+      "repository_url": "https://github.com/kyverno/kyverno",
+      "website_url": "https://kyverno.io",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "POLICY_EVALUATION",
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "kyverno.json"
+    },
+    {
+      "name": "Lagoon Insights Handler",
+      "publisher": "Lagoon",
+      "description": "Component that processes CycloneDX SBOMs and container image metadata for Lagoon environments, with vulnerability analysis via Trivy integration and customizable data filtering.",
+      "repository_url": "https://github.com/uselagoon/insights-handler",
+      "website_url": "https://lagoon.sh/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "CONTAINER_IMAGE",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "lagoon_insights_handler.json"
+    },
+    {
+      "name": "Lib4sbom",
+      "publisher": "Anthony Harrison",
+      "description": "Python library that parses, converts and generates SBOMs in CycloneDX and SPDX formats, allowing JSON, Tag, YAML and XML serialization and programmatic manipulation of packages, files and dependencies.",
+      "repository_url": "https://github.com/anthonyharrison/lib4sbom",
+      "website_url": "https://pypi.org/project/lib4sbom/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "lib4sbom.json"
+    },
+    {
+      "name": "License Scanner",
+      "publisher": "CycloneDX",
+      "description": "license-scanner is an Apache-2.0 Go library and CLI that detects SPDX-style licenses and legal terms in source files and outputs CycloneDX v1.4 SBOMs with detailed license data.",
+      "repository_url": "https://github.com/CycloneDX/license-scanner",
+      "website_url": "https://github.com/CycloneDX/license-scanner",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "license_scanner.json"
+    },
+    {
+      "name": "LicenseComplianceTool",
+      "publisher": "medavis GmbH",
+      "description": "Creates license manifests from CycloneDX SBOMs. Provides a Jenkins build step and CLI to list third-party components, their licenses, and download license texts to aid open-source compliance.",
+      "repository_url": "https://github.com/medavis-gmbh/LicenseComplianceTool",
+      "website_url": "https://github.com/medavis-gmbh/LicenseComplianceTool",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "JENKINS_PLUGIN",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "NODE.JS",
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "licensecompliancetool.json"
+    },
+    {
+      "name": "macaron",
+      "publisher": "Oracle",
+      "description": "Macaron is a supply chain security analysis tool and policy engine that checks conformance to frameworks such as SLSA, integrating CycloneDX SBOM generators or consuming existing SBOMs for automated analysis of build integrity and dependencies.",
+      "repository_url": "https://github.com/oracle/macaron",
+      "website_url": "https://oracle.github.io/macaron/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "PYTHON",
+        "SHELL"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC"
+      ],
+      "lifecycle": [
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "_fromFile": "macaron.json"
+    },
+    {
+      "name": "Manifest",
+      "publisher": "Manifest",
+      "description": "Manifest is a subscription SBOM management platform that auto-generates, aggregates, enriches, analyzes, and securely shares CycloneDX or SPDX SBOMs via web app and GitHub Action integration.",
+      "repository_url": "https://github.com/manifest-cyber/manifest-github-action",
+      "website_url": "https://manifestcyber.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "manifest.json"
+    },
+    {
+      "name": "mdbom",
+      "publisher": "Robert Hansel",
+      "description": "A simple command line tool to transform CycloneDX SBoMs to markdown.",
+      "repository_url": "https://github.com/HaRo87/mdbom",
+      "website_url": "https://haro87.github.io/mdbom/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "TRANSFORM"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "PYTHON",
+        "JAVASCRIPT/TYPESCRIPT",
+        "GO"
+      ],
+      "_fromFile": "mdbom.json"
+    },
+    {
+      "name": "MedScan",
+      "publisher": "MedSec",
+      "description": "Consumes SBOMs to help hospitals manage medical device assets, providing vulnerability and resource analysis for compliance and risk management.",
+      "repository_url": "https://www.medsec.com/",
+      "website_url": "https://www.medsec.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "RESOURCE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "medscan.json"
+    },
+    {
+      "name": "Mend SCA",
+      "publisher": "Mend (Whitesource)",
+      "description": "Mend SCA provides software composition analysis that scans direct and transitive open-source dependencies, enforces security and license policies, and exports CycloneDX or SPDX SBOMs with optional VEX data.",
+      "repository_url": "https://github.com/mend-toolkit/Mend-SBOM-Export-CLI",
+      "website_url": "https://www.mend.io/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "JENKINS_PLUGIN",
+        "AZURE_PIPELINE_EXTENSION"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON",
+        "GO",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "RUBY",
+        "C/C++"
+      ],
+      "_fromFile": "mend_sca.json"
+    },
+    {
+      "name": "meta-dependencytrack",
+      "publisher": "BG Networks",
+      "description": "meta-dependencytrack is a Yocto meta-layer which produces a CycloneDX Software Bill of Materials (aka SBOM) from your root filesystem and then uploads it to a Dependency-Track server against the project of your choice",
+      "repository_url": "https://github.com/bgnetworks/meta-dependencytrack",
+      "website_url": "https://github.com/bgnetworks/meta-dependencytrack",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "packaging": [
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON",
+        "SHELL"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
+      ],
+      "_fromFile": "meta_dependencytrack.json"
+    },
+    {
+      "name": "Meta Package Manager",
+      "publisher": "Kevin Deldycke",
+      "description": "Export a SBOM of all packages installed on a Linux, macOS or Windows system.",
+      "repository_url": "https://github.com/kdeldycke/meta-package-manager",
+      "website_url": "https://kdeldycke.github.io/meta-package-manager/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        ".NET",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
+      ],
+      "_fromFile": "meta_package_manager.json"
+    },
+    {
+      "name": "Meterian BOSS scanner",
+      "publisher": "Meterian",
+      "description": "Software composition analysis that inventories codebases and produces CycloneDX SBOMs while detecting security and licence risks across 12+ ecosystems.",
+      "repository_url": "https://github.com/MeterianHQ/meterian-github-action",
+      "website_url": "https://meterian.io/products/boss",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "FREEMIUM",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "SHELL"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "CPE"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "meterian_boss_scanner.json"
+    },
+    {
+      "name": "MLBOMdoc",
+      "publisher": "Anthony Harrison",
+      "description": "A command line tool which produces a human-readable representation of a CycloneDX ML Bill of Materials (MLBOM). Output formats include PDF and Markdown.",
+      "repository_url": "https://github.com/anthonyharrison/mlbomdoc",
+      "website_url": "https://pypi.org/project/mlbomdoc/",
+      "capabilities": [
+        "AI/ML-BOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "mlbomdoc.json"
+    },
+    {
+      "name": "Nancy",
+      "publisher": "Sonatype",
+      "description": "A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index",
+      "repository_url": "https://github.com/sonatype-nexus-community/nancy",
+      "website_url": "https://github.com/sonatype-nexus-community/nancy",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "nancy.json"
+    },
+    {
+      "name": "Neo4Cyclone",
+      "publisher": "Javier Dominguez",
+      "description": "Neo4Cyclone is a tool that allows you to visualise your SBOMs using Neo4J.",
+      "repository_url": "https://github.com/javixeneize/neo4cyclone",
+      "website_url": "https://github.com/javixeneize/neo4cyclone",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "neo4cyclone.json"
+    },
+    {
+      "name": "NetRise Platform",
+      "publisher": "NetRise",
+      "description": "The NetRise Platform generates SBOMs for binary code and post-build artifacts. It can ingest and analyze 3rd party SBOMs and provide guidance on risk mitigation, including CVEs, hardcoded credentials, cryptographic risk, and misconfigured services.",
+      "website_url": "https://www.netrise.io/",
+      "repository_url": "https://github.com/netriseinc",
+      "capabilities": [
+        "SBOM",
+        "CBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "RESOURCE_REPORTING",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_STANDARD"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "GITHUB_ACTION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "WINDOWS",
+        "MAC"
+      ],
+      "lifecycle": [
+        "DISCOVERY",
+        "OPERATIONS",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "CPE",
+        "PACKAGE_URL",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        ".NET",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS",
+        "PYTHON"
+      ],
+      "_fromFile": "netrise_platform.json"
+    },
+    {
+      "name": "Nexus IQ",
+      "publisher": "Sonatype",
+      "description": "Software Composition Analysis (SCA) platform that can consume, analyze, and produce CycloneDX SBOMs",
+      "website_url": "https://www.sonatype.com/product-nexus-lifecycle",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "SWIFT"
+      ],
+      "_fromFile": "nexus_iq.json"
+    },
+    {
+      "name": "Nexus Lifecycle Jenkins Plugin",
+      "publisher": "Sonatype",
+      "description": "Publishes CycloneDX SBOMs to Nexus IQ for per-build analysis, result visualization, and policy evaluation",
+      "repository_url": "https://github.com/jenkinsci/nexus-platform-plugin",
+      "website_url": "https://help.sonatype.com/en/sonatype-platform-plugin-for-jenkins.html",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "JENKINS_PLUGIN"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "nexus_lifecycle_jenkins_plugin.json"
+    },
+    {
+      "name": "nim_lk",
+      "publisher": "Emery Hemingway",
+      "description": "Create and update SBOMs for the Nim programing language. Includes a translation module for the Nimble package manager as well as a Nix expression for building packages from SBOMs.",
+      "repository_url": "https://git.sr.ht/~ehmry/nim_lk",
+      "website_url": "https://git.sr.ht/~ehmry/nim_lk",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "NIM"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "_fromFile": "nim_lk.json"
+    },
+    {
+      "name": "Noma",
+      "publisher": "Noma Security",
+      "description": "AI Application Security Platform for the entire AI lifecycle, focusing on AI asset discovery, ML-BOM, and AI supply chain risk management.",
+      "website_url": "https://noma.security",
+      "capabilities": [
+        "AI/ML-BOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DESIGN",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON",
+        "JAVA",
+        "C/C++",
+        ".NET",
+        "RUST",
+        "GO"
+      ],
+      "_fromFile": "noma.json"
+    },
+    {
+      "name": "NowSecure Platform",
+      "publisher": "NowSecure",
+      "description": "Mobile application security testing solution that automates static, dynamic and interactive testing, with SBOM capabilities through GitHub integrations",
+      "website_url": "https://www.nowsecure.com/products/nowsecure-platform/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "OUTDATED_COMPONENTS"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "nowsecure_platform.json"
+    },
+    {
+      "name": "Ochrona CLI",
+      "publisher": "Ochrona",
+      "description": "A command line tool for detecting vulnerabilities in Python dependencies and doing safe package installs. Outputs CycloneDX SBOMs and supports policy enforcement.",
+      "repository_url": "https://github.com/ochronasec/ochrona-cli",
+      "website_url": "https://ochrona.dev/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "ochrona_cli.json"
+    },
+    {
+      "name": "Oligo Runtime SBOM",
+      "publisher": "Oligo",
+      "description": "Oligo Security delivers instant insights into actively executed libraries, assessing open source risks and confirming exploitability. It enables CycloneDX SBOM creation and auto-generates VEX.",
+      "website_url": "https://www.oligo.security/",
+      "repository_url": "https://www.oligo.security/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        ".NET",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
+      ],
+      "_fromFile": "oligo_runtime_sbom.json"
+    },
+    {
+      "name": "ONEKEY firmware analysis platform",
+      "publisher": "ONEKEY",
+      "description": "Cloud-based platform that automatically extracts firmware images, enumerates components, and produces CycloneDX SBOM and vulnerability reports.",
+      "website_url": "https://onekey.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "OUTDATED_COMPONENTS",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "_fromFile": "onekey_firmware_analysis_platform.json"
+    },
+    {
+      "name": "OpenRewrite",
+      "publisher": "OpenRewrite Project",
+      "description": "Open-source automated refactoring ecosystem for code transformation, security remediation, and dependency management through reusable recipes and build tool plugins.",
+      "repository_url": "https://github.com/openrewrite/rewrite",
+      "website_url": "https://docs.openrewrite.org/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "TRANSFORM",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "RESOURCE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "LIBRARY",
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY",
+        "MAVEN_PLUGIN"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "JAVA",
+        "KOTLIN",
+        "GROOVY",
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "openrewrite.json"
+    },
+    {
+      "name": "OSS Inventory",
+      "publisher": "Thiago Pinto",
+      "description": "A web application for importing, storing, and visualizing CycloneDX SBOMs, allowing organizations to track software components across projects.",
+      "repository_url": "https://github.com/thspinto/oss_inventory",
+      "website_url": "https://github.com/thspinto/oss_inventory",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "RESOURCE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "oss_inventory.json"
+    },
+    {
+      "name": "OSS Review Toolkit (ORT)",
+      "publisher": "OSS Review Toolkit",
+      "description": "A comprehensive suite of tools to automate software compliance checks, analyze dependencies / vulnerabilities, and generate reports.",
+      "repository_url": "https://github.com/oss-review-toolkit/ort",
+      "website_url": "https://oss-review-toolkit.org/",
+      "capabilities": [
+        "SBOM",
+        "CBOM",
+        "OBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "LIBRARY",
+        "APPLICATION",
+        "GITHUB_ACTION",
+        "GITLAB_CI_TEMPLATE",
+        "JENKINS_PLUGIN"
+      ],
+      "library": [
+        "JAVA",
+        "KOTLIN"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "CPE",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.1",
+        "CYCLONEDX_V1.0"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        ".NET",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "KOTLIN",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
         "RUST",
         "SCALA",
+        "SWIFT"
+      ],
+      "_fromFile": "oss_review_toolkit_ort_.json"
+    },
+    {
+      "name": "OSV",
+      "publisher": "Google",
+      "description": "Open source vulnerability database and scanner that accepts CycloneDX SBOMs as input and identifies known vulnerabilities in components across multiple ecosystems.",
+      "repository_url": "https://github.com/google/osv.dev",
+      "website_url": "https://osv.dev/",
+      "capabilities": [
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "PYTHON",
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        ".NET"
+      ],
+      "_fromFile": "osv.json"
+    },
+    {
+      "name": "Parlay",
+      "publisher": "Snyk",
+      "description": "Parlay is an Apache-licensed CLI written in Go that takes CycloneDX 1.4 JSON/XML or SPDX 2.3 SBOMs and enriches them with licence, vulnerability, maintainer and scorecard data from services like ecosyste.ms, Snyk and OpenSSF.",
+      "repository_url": "https://github.com/snyk/parlay",
+      "website_url": "https://github.com/snyk/parlay",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "_fromFile": "parlay.json"
+    },
+    {
+      "name": "pip-audit",
+      "publisher": "Trail of Bits",
+      "description": "Audits Python environments and dependency trees for known vulnerabilities and can emit CycloneDX SBOMs of affected components.",
+      "repository_url": "https://github.com/pypa/pip-audit",
+      "website_url": "https://github.com/pypa/pip-audit",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "pip_audit.json"
+    },
+    {
+      "name": "Prisma Cloud",
+      "publisher": "Palo Alto Networks",
+      "description": "Unified cloud-native application protection platform that scans code, pipelines, infrastructure and runtime to generate CycloneDX SBOMs, analyze vulnerabilities, licenses and misconfigurations, and secure entitlements across multi-cloud environments.",
+      "website_url": "https://www.paloaltonetworks.com/prisma/cloud",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "JENKINS_PLUGIN"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY"
+      ],
+      "_fromFile": "prisma_cloud.json"
+    },
+    {
+      "name": "ProCap360",
+      "publisher": "Internet Infrastructure Services Corp.",
+      "description": "An advanced SBOM, RBOM and AIBOM  cybersecurity risk management tool using novel knowledge graph technology to enhance software supply chain security and visually display real time application assurance.",
+      "repository_url": "https://github.com/ProCap360",
+      "website_url": "https://procap360.com",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "CBOM",
+        "HBOM",
+        "OBOM",
+        "AI/ML-BOM",
+        "VDR/VEX",
+        "CDXA",
+        "RELEASE_NOTES"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "SIGNING/NOTARY",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS",
+        "POLICY_EVALUATION",
+        "RESOURCE_REPORTING",
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "AZURE_PIPELINE_EXTENSION"
+      ],
+      "library": [
+        "GO",
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "C/C++"
+      ],
+      "_fromFile": "procap360.json"
+    },
+    {
+      "name": "Product Security Hub (PSH)",
+      "publisher": "Product Security Hub, LLC",
+      "description": "Cloud-based tool to import, export, view, create, edit, and transform CycloneDX SBOMs and human-readable SBOMs, as well as manage VEX data.",
+      "website_url": "https://www.ProductSecurityHub.com/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "_fromFile": "product_security_hub_psh_.json"
+    },
+    {
+      "name": "Project Piper",
+      "publisher": "SAP",
+      "description": "Project Piper is an open-source Jenkins shared library and CLI that automates SAP-centric CI/CD pipelines and can generate CycloneDX SBOMs for Maven, Python, Go, container, and other builds.",
+      "repository_url": "https://github.com/SAP/jenkins-library",
+      "website_url": "https://www.project-piper.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [],
+      "transform": [],
+      "packaging": [
+        "LIBRARY",
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "PYTHON",
+        "GO",
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "project_piper.json"
+    },
+    {
+      "name": "PulseUno Plugin for Dimensions CM",
+      "publisher": "Micro Focus",
+      "description": "PulseUno enables development teams to continually build and inspect the health and quality of code using plugins such as CycloneDX. Teams can use this information for merge, deployment, and release decisions.",
+      "repository_url": "https://www.microfocus.com/en-us/products/dimensions-cm",
+      "website_url": "https://www.microfocus.com/en-us/products/dimensions-cm",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "PACKAGE_MANAGER_INTEGRATION",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "RESOURCE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "pulseuno_plugin_for_dimensions_cm.json"
+    },
+    {
+      "name": "RapidFort",
+      "publisher": "RapidFort",
+      "description": "Container-optimization platform that scans, profiles and hardens images, generates SBOMs, converts to CycloneDX/SPDX, and exports VEX to prioritize exploitable CVEs.",
+      "website_url": "https://www.rapidfort.com/",
+      "repository_url": "https://github.com/rapidfort/community-images",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "TRANSFORM",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "rapidfort.json"
+    },
+    {
+      "name": "ReARM",
+      "publisher": "Reliza",
+      "description": "ReARM is a system to store, organize and manage SBOMs / xBOMs with Component and Product releases.",
+      "repository_url": "https://github.com/relizaio/rearm",
+      "website_url": "https://rearmhq.com",
+      "capabilities": [
+        "AI/ML-BOM",
+        "CBOM",
+        "CDXA",
+        "OBOM",
+        "RELEASE_NOTES",
+        "SAASBOM",
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DECOMMISSION"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        ".NET",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON",
+        "GO",
+        "NODE.JS"
+      ],
+      "_fromFile": "rearm.json"
+    },
+    {
+      "name": "Rebom",
+      "publisher": "Reliza",
+      "description": "Open source catalog for storing, managing, and distributing CycloneDX Software Bills of Materials (SBOMs) in JSON format, with features for validation, merging, and analysis.",
+      "repository_url": "https://github.com/relizaio/rebom",
+      "website_url": "https://rebomdemo.relizahub.com",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "DISTRIBUTE",
+        "ANALYSIS",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING",
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [
+        "BOM_VERSION",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "CONTAINER_IMAGE",
+        "APPLICATION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "rebom.json"
+    },
+    {
+      "name": "Reliza Hub",
+      "publisher": "Reliza",
+      "description": "Publishes and ingests SBOMs for metadata management, compliance, and distribution. Supports CycloneDX and SPDX standards for software supply chain transparency.",
+      "repository_url": "https://relizahub.com/",
+      "website_url": "https://relizahub.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "DISTRIBUTE",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "RESOURCE_REPORTING",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "WINDOWS",
+        "MAC"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "reliza_hub.json"
+    },
+    {
+      "name": "Retire.js",
+      "publisher": "RetireJS",
+      "description": "Scanner that detects the use of JavaScript libraries with known vulnerabilities in web and Node.js applications and can generate CycloneDX-format SBOMs.",
+      "repository_url": "https://github.com/RetireJS/retire.js",
+      "website_url": "https://retirejs.github.io/retire.js",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS"
+      ],
+      "_fromFile": "retire_js.json"
+    },
+    {
+      "name": "Rezilion Dynamic SBOM",
+      "publisher": "Rezilion",
+      "description": "Continuous, runtime-aware SBOM platform that inventories every file, package and dependency across Windows and Linux hosts, containers and CI/CD pipelines, exports CycloneDX/VEX and validates vulnerability exploitability in real time.",
+      "website_url": "https://www.rezilion.com/platform/dynamic-sbom",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "JENKINS_PLUGIN",
+        "GITLAB_CI_TEMPLATE"
+      ],
+      "platform": [
+        "LINUX",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PYTHON",
+        "RUBY"
+      ],
+      "_fromFile": "rezilion_dynamic_sbom.json"
+    },
+    {
+      "name": "RKVST SBOM Hub",
+      "publisher": "RKVST",
+      "description": "Free SaaS repository to discover, store and permission-share CycloneDX v1.4 SBOMs with immutable provenance, VEX support and continuous assurance.",
+      "repository_url": "https://github.com/jitsuin-inc/archivist-samples",
+      "website_url": "https://www.datatrails.ai/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "FREEMIUM"
+      ],
+      "functions": [
+        "DISTRIBUTE",
+        "SIGNING/NOTARY"
+      ],
+      "analysis": [],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SWID"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "rkvst_sbom_hub.json"
+    },
+    {
+      "name": "Rollup Plugin SBOM",
+      "publisher": "Jan Biasi",
+      "description": "Creates CycloneDX SBOMs for frontend Javascript apps bundled with rollup or vite.",
+      "repository_url": "https://github.com/janbiasi/rollup-plugin-sbom",
+      "website_url": "https://www.npmjs.com/package/rollup-plugin-sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "packaging": [
+        "ROLLUP_PLUGIN"
+      ],
+      "_fromFile": "rollup_plugin_sbom.json"
+    },
+    {
+      "name": "RunSafe C/C++ Build-time SBOM Generator",
+      "publisher": "RunSafe Security",
+      "description": "Generates a C/C++ SBOM at build-time without a package manager, working across build environments and reporting on all library dependencies.",
+      "website_url": "https://runsafesecurity.com/c-c-plus-plus-sbom/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "C/C++"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "C/C++"
+      ],
+      "_fromFile": "runsafe_c_c_build_time_sbom_generator.json"
+    },
+    {
+      "name": "Salus",
+      "publisher": "Coinbase",
+      "description": "Salus is a tool for coordinating the execution of security scanners. Salus can generate CycloneDX SBOMs from many language ecosystems.",
+      "repository_url": "https://github.com/coinbase/salus",
+      "website_url": "https://github.com/coinbase/salus",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "supportedLanguages": [
+        "RUBY",
+        "JAVASCRIPT/TYPESCRIPT",
+        "NODE.JS",
+        "PYTHON",
+        "GO",
+        "RUST"
+      ],
+      "_fromFile": "salus.json"
+    },
+    {
+      "name": "SBOM2doc",
+      "publisher": "Anthony Harrison",
+      "description": "SBOM2doc converts CycloneDX or SPDX SBOMs into human-readable reports in PDF, Markdown, HTML, Excel or console formats via a cross-platform Python CLI.",
+      "repository_url": "https://github.com/anthonyharrison/sbom2doc",
+      "website_url": "https://pypi.org/project/sbom2doc/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "TRANSFORM",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "sbom2doc.json"
+    },
+    {
+      "name": "SBOM2dot",
+      "publisher": "Anthony Harrison",
+      "description": "CLI that reads CycloneDX or SPDX SBOMs and emits a GraphViz-compatible DOT file so you can visualise component and dependency relationships.",
+      "repository_url": "https://github.com/anthonyharrison/sbom2dot",
+      "website_url": "https://pypi.org/project/sbom2dot/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "TRANSFORM",
+        "ANALYSIS"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "sbom2dot.json"
+    },
+    {
+      "name": "SBOM4Files",
+      "publisher": "Anthony Harrison",
+      "description": "Command-line tool that scans a directory and generates CycloneDX (JSON) or SPDX SBOMs for its files.",
+      "repository_url": "https://github.com/anthonyharrison/sbom4files",
+      "website_url": "https://pypi.org/project/sbom4files/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "sbom4files.json"
+    },
+    {
+      "name": "SBOM4Python",
+      "publisher": "Anthony Harrison",
+      "description": "CLI utility that produces CycloneDX or SPDX SBOMs for installed Python modules or requirements files, identifying dependencies and their licenses, with optional dependency graph output.",
+      "repository_url": "https://github.com/anthonyharrison/sbom4python",
+      "website_url": "https://pypi.org/project/sbom4python/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "sbom4python.json"
+    },
+    {
+      "name": "SBOM4Rust",
+      "publisher": "Anthony Harrison",
+      "description": "CLI that reads Cargo.lock and authors CycloneDX v1.6 or SPDX SBOMs for Rust projects.",
+      "repository_url": "https://github.com/anthonyharrison/sbom4rust",
+      "website_url": "https://github.com/anthonyharrison/sbom4rust",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "RUST"
+      ],
+      "_fromFile": "sbom4rust.json"
+    },
+    {
+      "name": "sbom-action",
+      "publisher": "Pete Wagner",
+      "description": "GitHub Action that fetches and diffs CycloneDX SBOMs for container images, posting comments or opening pull requests when package or vulnerability changes are detected.",
+      "repository_url": "https://github.com/thepwagner/sbom-action",
+      "website_url": "https://github.com/thepwagner/sbom-action",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "sbom_action.json"
+    },
+    {
+      "name": "SBOM Assembler",
+      "publisher": "Interlynk.io",
+      "description": "sbomasm is a command-line tool that assembles product SBOMs from component SBOMs, supporting CycloneDX and SPDX formats for streamlined management and distribution.",
+      "repository_url": "https://github.com/interlynk-io/sbomasm",
+      "website_url": "https://www.interlynk.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "TRANSFORM"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "sbom_assembler.json"
+    },
+    {
+      "name": "SBOM Benchmark",
+      "publisher": "Interlynk.io",
+      "description": "SBOM Benchmark is an Apache-licensed web application that scores CycloneDX 1.4/1.5 and SPDX SBOMs for quality and compliance, generating shareable reports via the sbomqs engine.",
+      "repository_url": "https://github.com/interlynk-io/sbombenchmark.dev",
+      "website_url": "https://sbombenchmark.dev/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED",
+        "FREEMIUM"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "_fromFile": "sbom_benchmark.json"
+    },
+    {
+      "name": "SBOM CLI",
+      "publisher": "Defense Unicorns",
+      "description": "Creates CycloneDX SBOMs from Kubernetes Helm charts",
+      "capabilities": [],
+      "availability": [],
+      "functions": [],
+      "packaging": [],
+      "platform": [],
+      "lifecycle": [],
+      "supportedStandards": [],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "sbom_cli.json"
+    },
+    {
+      "name": "SBOM Explorer",
+      "publisher": "Interlynk.io",
+      "description": "sbomex is a command line utility to help query and pull from Interlynk's public SBOM repository.",
+      "repository_url": "https://github.com/interlynk-io/sbomex",
+      "website_url": "https://www.interlynk.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "DISTRIBUTE"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "sbom_explorer.json"
+    },
+    {
+      "name": "SBOM Grep",
+      "publisher": "Interlynk.io",
+      "description": "Command-line utility (`sbomgr`) that performs grep-style searches across SBOMs by name, checksum, CPE, and PURL.",
+      "repository_url": "https://github.com/interlynk-io/sbomgr",
+      "website_url": "https://www.interlynk.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "_fromFile": "sbom_grep.json"
+    },
+    {
+      "name": "SBOM Insights",
+      "publisher": "Revenera",
+      "description": "SBOM Insights is a subscription-based SaaS platform that ingests SBOMs in CycloneDX and SPDX formats, reconciles and analyzes components for vulnerabilities, license compliance and outdated parts, and generates reports and compliance artifacts.",
+      "website_url": "https://www.revenera.com/software-composition-analysis/products/sbom-insights",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "TRANSFORM",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "_fromFile": "sbom_insights.json"
+    },
+    {
+      "name": "SBOM-Manager",
+      "publisher": "Anthony Harrison",
+      "description": "SBOM-Manager is an open-source Python CLI that stores, queries, and scans CycloneDX 1.4/1.5 and SPDX 2.3 SBOMs via a local repository to support audit and vulnerability investigations.",
+      "repository_url": "https://github.com/anthonyharrison/sbom-manager",
+      "website_url": "https://pypi.org/project/sbom-manager/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "_fromFile": "sbom_manager.json"
+    },
+    {
+      "name": "SBOM Observer",
+      "publisher": "Bytesafe",
+      "description": "SBOM Observer provides a comprehensive SBOM workflow to help you manage your software supply chain. Leverage the powerful combination of the Policy Engine and Operational Model to guarantee the security and compliance of your software.",
+      "website_url": "https://sbom.observer/",
+      "repository_url": "https://github.com/marketplace/actions/sbom-observer-scan-and-upload",
+      "capabilities": [
+        "SBOM",
+        "RELEASE_NOTES",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "RESOURCE_REPORTING",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION",
+        "CONTAINER_IMAGE"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "SLSA"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
         "SWIFT",
+        "ERLANG_ELIXIR",
+        "SCALA",
         "KOTLIN",
         "GROOVY",
         "FORTRAN"
-      ]
+      ],
+      "_fromFile": "sbom_observer.json"
+    },
+    {
+      "name": "SBOM-Operator",
+      "publisher": "Christian Kotzbauer",
+      "description": "Catalogue all container images running in a Kubernetes cluster and publish Software Bill of Materials (SBOM) documents, generated with Syft, to multiple back-ends.",
+      "repository_url": "https://github.com/ckotzbauer/sbom-operator",
+      "website_url": "https://github.com/ckotzbauer/sbom-operator",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [],
+      "transform": [],
+      "packaging": [
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "sbom_operator.json"
+    },
+    {
+      "name": "SBOM Quality Score",
+      "publisher": "Interlynk.io",
+      "description": "Command-line utility that evaluates the quality and compliance of CycloneDX and SPDX SBOMs across multiple categories, enabling automated policy gates in CI/CD workflows.",
+      "repository_url": "https://github.com/interlynk-io/sbomqs",
+      "website_url": "https://www.interlynk.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "_fromFile": "sbom_quality_score.json"
+    },
+    {
+      "name": "sbom-rs",
+      "publisher": "Paul Sastrasinh",
+      "description": "A group of Rust projects for interacting with and producing software bill of materials (SBOMs).",
+      "repository_url": "https://github.com/psastras/sbom-rs",
+      "website_url": "https://github.com/psastras/sbom-rs",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "RUST"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "RUST"
+      ],
+      "_fromFile": "sbom_rs.json"
+    },
+    {
+      "name": "SBOM Scorecard",
+      "publisher": "eBay",
+      "description": "SBOM Scorecard evaluates SBOMs for specification compliance, generation metadata, and package details, supporting CycloneDX, SPDX, and Syft formats.",
+      "repository_url": "https://github.com/eBay/sbom-scorecard",
+      "website_url": "https://github.com/eBay/sbom-scorecard",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "library": [
+        "GO"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "sbom_scorecard.json"
+    },
+    {
+      "name": "SBOM.sh",
+      "publisher": "Codenotary Inc",
+      "description": "SBOM.sh is a free service to store, visualize and globally share CycloneDX SBOM files by simply using HTTP requests or curl.",
+      "repository_url": "https://github.com/codenotary/sbom.sh-container",
+      "website_url": "https://sbom.sh",
+      "capabilities": [
+        "SBOM",
+        "RELEASE_NOTES"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "FREEMIUM"
+      ],
+      "functions": [
+        "DISTRIBUTE",
+        "AUTHOR",
+        "SIGNING/NOTARY"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "SHELL"
+      ],
+      "platform": [
+        "LINUX"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "sbom_sh.json"
+    },
+    {
+      "name": "sbom-submission-action",
+      "publisher": "TietoEVRY",
+      "description": "GitHub Action that uploads CycloneDX SBOM files to GitHub\u2019s dependency submission API, enabling Dependabot security analysis downstream.",
+      "repository_url": "https://github.com/evryfs/sbom-dependency-submission-action",
+      "website_url": "https://github.com/marketplace/actions/sbom-submission-action",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "DISTRIBUTE"
+      ],
+      "analysis": [],
+      "transform": [],
+      "packaging": [
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "sbom_submission_action.json"
     },
     {
       "name": "sbom-swissarmy-bitbucket-pipe",
@@ -10752,61 +10174,17 @@
         "KOTLIN",
         "GROOVY",
         "FORTRAN"
-      ]
+      ],
+      "_fromFile": "sbom_swissarmy_bitbucket_pipe.json"
     },
     {
-      "name": "cyclonedx-merge",
-      "publisher": "fnxpt",
-      "description": "Tool to merge CycloneDX files (JSON/XML) with support for normal, flat, and smart merge modes.",
-      "repository_url": "https://github.com/fnxpt/cyclonedx-merge",
-      "website_url": "https://github.com/fnxpt/cyclonedx-merge",
+      "name": "SBOM Utility (sbom-utility)",
+      "publisher": "CycloneDX",
+      "description": "Go-based CLI and API to validate, query, trim and patch CycloneDX or SPDX BOMs, report on components, licences and vulnerabilities, and handle all CycloneDX variants up to v1.6.",
+      "repository_url": "https://github.com/CycloneDX/sbom-utility",
+      "website_url": "https://github.com/CycloneDX/sbom-utility",
       "capabilities": [
         "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "TRANSFORM"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "cyclonedx-enrich",
-      "publisher": "fnxpt",
-      "description": "Enrich CycloneDX SBOM files by applying enrichers to improve data quality, including licenses, hashes, properties, and references.",
-      "repository_url": "https://github.com/fnxpt/cyclonedx-enrich",
-      "website_url": "https://github.com/fnxpt/cyclonedx-enrich",
-      "capabilities": [
-        "SBOM",
-        "CBOM"
       ],
       "availability": [
         "OPEN_SOURCE",
@@ -10817,15 +10195,12 @@
         "TRANSFORM"
       ],
       "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION"
       ],
       "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
+        "COMMAND_LINE_UTILITY"
       ],
       "library": [
         "GO"
@@ -10836,30 +10211,29 @@
         "WINDOWS"
       ],
       "lifecycle": [
+        "BUILD",
         "POST-BUILD",
         "OPERATIONS"
       ],
       "supportedStandards": [
-        "CYCLONEDX"
+        "CYCLONEDX",
+        "SPDX"
       ],
       "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.6",
         "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
       ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "RUBY"
-      ]
+      "_fromFile": "sbom_utility_sbom_utility_.json"
     },
     {
-      "name": "sbom-rs",
-      "publisher": "Paul Sastrasinh",
-      "description": "A group of Rust projects for interacting with and producing software bill of materials (SBOMs).",
-      "repository_url": "https://github.com/psastras/sbom-rs",
-      "website_url": "https://github.com/psastras/sbom-rs",
+      "name": "sbom-validator",
+      "publisher": "ShiftLeftCyber",
+      "description": "A lightweight Go library for validating Software Bill of Materials (SBOM) against industry-standard specifications.",
+      "repository_url": "https://github.com/shiftleftcyber/sbom-validator",
+      "website_url": "https://shiftleftcyber.io",
       "capabilities": [
         "SBOM"
       ],
@@ -10867,18 +10241,21 @@
         "OPEN_SOURCE"
       ],
       "functions": [
-        "AUTHOR",
         "ANALYSIS"
       ],
       "analysis": [
-        "SECURITY_VULNERABILITIES"
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
       ],
       "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION"
+        "LIBRARY"
       ],
       "library": [
-        "RUST"
+        "GO"
       ],
       "platform": [
         "LINUX",
@@ -10887,6 +10264,216 @@
       ],
       "lifecycle": [
         "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "GO"
+      ],
+      "_fromFile": "sbom_validator.json"
+    },
+    {
+      "name": "SBOM Vendor Management",
+      "publisher": "SettleTop, Inc.",
+      "description": "Manage, assess, store and monitor all your vendor\u2019s SBOMs in one secure, centralized dashboard to improve supply chain security.",
+      "website_url": "https://www.settletop.com/sbom",
+      "repository_url": "https://www.settletop.com/sbom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "_fromFile": "sbom_vendor_management.json"
+    },
+    {
+      "name": "SBOMAudit",
+      "publisher": "Anthony Harrison",
+      "description": "SBOMAudit is a command-line utility that audits CycloneDX or SPDX SBOMs against NTIA minimum requirements, license policies, allow/deny lists, and package age to flag outdated or non-compliant components.",
+      "repository_url": "https://github.com/anthonyharrison/sbomaudit",
+      "website_url": "https://pypi.org/project/sbomaudit/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "CPE",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "PERL",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "sbomaudit.json"
+    },
+    {
+      "name": "SBOMcenter",
+      "publisher": "Codenotary Inc",
+      "description": "SBOMcenter.io is a free service to get insights into the ingredients of your software for free and without any software.",
+      "website_url": "https://sbomcenter.io",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "FREEMIUM"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION",
+        "CONTAINER_IMAGE"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "PYTHON",
+        "JAVASCRIPT/TYPESCRIPT",
+        "GO",
+        "RUST"
+      ],
+      "_fromFile": "sbomcenter.json"
+    },
+    {
+      "name": "SBOMDiff",
+      "publisher": "Anthony Harrison",
+      "description": "SBOMDiff is an Apache-2.0 CLI that compares two SBOM files (CycloneDX 1.4 or SPDX 2.3), highlighting package additions, removals, version or license changes, and outputs text, JSON or YAML reports.",
+      "repository_url": "https://github.com/anthonyharrison/sbomdiff",
+      "website_url": "https://pypi.org/project/sbomdiff/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
         "POST-BUILD"
       ],
       "supportedStandards": [
@@ -10896,29 +10483,81 @@
       "cycloneDxVersion": [
         "CYCLONEDX_V1.4"
       ],
-      "supportedLanguages": [
-        "RUST"
-      ]
+      "_fromFile": "sbomdiff.json"
     },
     {
-      "name": "MLBOMdoc",
-      "publisher": "Anthony Harrison",
-      "description": "A command line tool which produces a human-readable representation of a CycloneDX ML Bill of Materials (MLBOM). Output formats include PDF and Markdown.",
-      "repository_url": "https://github.com/anthonyharrison/mlbomdoc",
-      "website_url": "https://pypi.org/project/mlbomdoc/",
+      "name": "sbomify",
+      "publisher": "sbomify",
+      "description": "sbomify is a comprehensive SBOM management platform that enables secure sharing and analysis of Software Bill of Materials. Seamlessly integrates with CI/CD pipelines.",
+      "website_url": "https://sbomify.com",
+      "repository_url": "https://github.com/sbomify/sbomify",
       "capabilities": [
-        "AI/ML-BOM"
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE",
+        "TRANSFORM"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "sbomify.json"
+    },
+    {
+      "name": "SBOMMerge",
+      "publisher": "Anthony Harrison",
+      "description": "Command-line utility that merges two SBOM files, supporting CycloneDX and SPDX inputs and outputs in tag, JSON or YAML formats.",
+      "repository_url": "https://github.com/anthonyharrison/sbommerge",
+      "website_url": "https://pypi.org/project/sbommerge/",
+      "capabilities": [
+        "SBOM"
       ],
       "availability": [
         "OPEN_SOURCE",
         "OSI_APPROVED"
       ],
       "functions": [
-        "AUTHOR",
         "TRANSFORM"
       ],
-      "analysis": [],
       "transform": [
+        "BOM_STANDARD",
         "BOM_SERIALIZATION_FORMAT"
       ],
       "packaging": [
@@ -10933,19 +10572,17 @@
         "WINDOWS"
       ],
       "lifecycle": [
-        "BUILD",
         "POST-BUILD"
       ],
       "supportedStandards": [
-        "CYCLONEDX"
+        "CYCLONEDX",
+        "SPDX"
       ],
       "cycloneDxVersion": [
         "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
+        "CYCLONEDX_V1.4"
       ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
+      "_fromFile": "sbommerge.json"
     },
     {
       "name": "SBOMTrend",
@@ -10990,20 +10627,66 @@
       ],
       "supportedLanguages": [
         "PYTHON"
-      ]
+      ],
+      "_fromFile": "sbomtrend.json"
     },
     {
-      "name": "Oligo Runtime SBOM",
-      "publisher": "Oligo",
-      "description": "Oligo Security delivers instant insights into actively executed libraries, assessing open source risks and confirming exploitability. It enables CycloneDX SBOM creation and auto-generates VEX.",
-      "website_url": "https://www.oligo.security/",
-      "repository_url": "https://www.oligo.security/",
+      "name": "sca-codeinsight-reports-cyclonedx",
+      "publisher": "Flexera",
+      "description": "Generates CycloneDX SBOM reports (XML and JSON) for projects scanned in Flexera Code Insight.",
+      "repository_url": "https://github.com/flexera-public/sca-codeinsight-reports-cyclonedx",
+      "website_url": "https://github.com/flexera-public/sca-codeinsight-reports-cyclonedx",
       "capabilities": [
         "SBOM",
         "VDR/VEX"
       ],
       "availability": [
-        "COMMERCIAL_LICENSE"
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "_fromFile": "sca_codeinsight_reports_cyclonedx.json"
+    },
+    {
+      "name": "Scancode Toolkit",
+      "publisher": "nexB",
+      "description": "Detects licenses, copyrights, package manifests & dependencies by scanning code to discover and inventory open source and third-party packages",
+      "repository_url": "https://github.com/nexB/scancode-toolkit",
+      "website_url": "https://github.com/nexB/scancode-toolkit",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
       ],
       "functions": [
         "ANALYSIS",
@@ -11011,190 +10694,76 @@
       ],
       "analysis": [
         "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
+        "LICENSE_REPORTING",
+        "RESOURCE_REPORTING"
       ],
       "packaging": [
         "COMMAND_LINE_UTILITY",
         "CONTAINER_IMAGE"
       ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        ".NET",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "bogrod",
-      "publisher": "productaize",
-      "description": "A command line tool to manage SBOM and VEX like source code and to distribute SBOMs to notaries.",
-      "repository_url": "https://github.com/productaize/bogrod",
-      "website_url": "https://github.com/productaize/bogrod",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "DISTRIBUTE"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
       "library": [
         "PYTHON"
       ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
       "platform": [
         "LINUX",
         "MAC",
         "WINDOWS"
       ],
       "lifecycle": [
-        "OPERATIONS",
+        "BUILD",
+        "POST-BUILD",
         "DISCOVERY"
       ],
       "supportedStandards": [
-        "CYCLONEDX"
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
       ],
       "cycloneDxVersion": [
         "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "ARIANNA",
-      "publisher": "Security Pattern",
-      "description": "SBOM, HBOM and vulnerability management platform for intelligent connect devices. Show compliance to regulations and standards and manage risk across the entire product lifecycle.",
-      "website_url": "https://www.securitypattern.com/arianna-security-management-platform",
-      "capabilities": [
-        "SBOM",
-        "HBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DESIGN",
-        "BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CPE",
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5"
+        "CYCLONEDX_V1.3"
       ],
       "supportedLanguages": [
         "C/C++",
+        "GO",
         "JAVA",
         "JAVASCRIPT/TYPESCRIPT",
         ".NET",
+        "NODE.JS",
+        "PERL",
+        "PHP",
         "PYTHON",
-        "PHP"
-      ]
+        "RUBY",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "scancode_toolkit.json"
     },
     {
-      "name": "SBOM Vendor Management",
-      "publisher": "SettleTop, Inc.",
-      "description": "Manage, assess, store and monitor all your vendor’s SBOMs in one secure, centralized dashboard to improve supply chain security.",
-      "website_url": "https://www.settletop.com/sbom",
-      "repository_url": "https://www.settletop.com/sbom",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "OPERATIONS",
-        "DISCOVERY"
-      ]
-    },
-    {
-      "name": "Rollup Plugin SBOM",
-      "publisher": "Jan Biasi",
-      "description": "Creates CycloneDX SBOMs for frontend Javascript apps bundled with rollup or vite.",
-      "repository_url": "https://github.com/janbiasi/rollup-plugin-sbom",
-      "website_url": "https://www.npmjs.com/package/rollup-plugin-sbom",
-      "capabilities": [
-        "SBOM"
-      ],
+      "name": "SCANOSS",
+      "publisher": "SCANOSS",
+      "description": "Open source software identification and inventory tool that provides insights into license compliance, security vulnerabilities, and software composition analysis",
+      "repository_url": "https://github.com/scanoss/engine",
+      "website_url": "https://www.scanoss.com/",
+      "capabilities": [],
       "availability": [
         "OPEN_SOURCE"
       ],
       "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
       ],
       "lifecycle": [
         "BUILD",
@@ -11202,53 +10771,45 @@
       ],
       "supportedStandards": [
         "CYCLONEDX",
+        "SPDX",
         "PACKAGE_URL"
       ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5"
-      ],
       "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT"
+        "C/C++",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
       ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "packaging": [
-        "ROLLUP_PLUGIN"
-      ]
+      "_fromFile": "scanoss.json"
     },
     {
-      "name": "Product Security Hub (PSH)",
-      "publisher": "Product Security Hub, LLC",
-      "description": "Cloud-based tool to import, export, view, create, edit, and transform CycloneDX SBOMs and human-readable SBOMs, as well as manage VEX data.",
-      "website_url": "https://www.ProductSecurityHub.com/",
+      "name": "SecObserve",
+      "publisher": "MaibornWolff",
+      "description": "Open-source platform that aggregates findings and CycloneDX SBOMs from many scanners, lets teams assess security and license risks, and reports results via dashboards and APIs.",
+      "repository_url": "https://github.com/MaibornWolff/SecObserve",
+      "website_url": "https://maibornwolff.github.io/SecObserve",
       "capabilities": [
-        "SBOM",
-        "VDR/VEX"
+        "SBOM"
       ],
       "availability": [
-        "COMMERCIAL_LICENSE"
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
       ],
       "functions": [
         "ANALYSIS",
-        "AUTHOR",
-        "TRANSFORM"
+        "DISTRIBUTE"
       ],
       "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
       ],
       "packaging": [
-        "APPLICATION"
+        "APPLICATION",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "PYTHON",
+        "JAVASCRIPT_TYPESCRIPT"
       ],
       "platform": [
         "LINUX",
@@ -11264,10 +10825,961 @@
         "CYCLONEDX"
       ],
       "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "KOTLIN"
+      ],
+      "_fromFile": "secobserve.json"
+    },
+    {
+      "name": "SecureStack",
+      "publisher": "SecureStack",
+      "description": "SecureStack analyzes your application and finds all source code, cloud stack and third-party services and builds a CycloneDX SBOM every time you deploy",
+      "repository_url": "https://github.com/SecureStackCo/actions-sbom",
+      "website_url": "https://securestack.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "FREEMIUM",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "DISTRIBUTE",
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "RESOURCE_REPORTING",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON"
+      ],
+      "_fromFile": "securestack.json"
+    },
+    {
+      "name": "Semgrep",
+      "publisher": "Semgrep Inc",
+      "description": "Semgrep is an application security platform where developers can scan for vulnerabilities in code (SAST), in OSS dependencies (SCA), and secrets. Semgrep creates CycloneDX SBOMs that enrich vulnerabilities with reachability analysis.",
+      "website_url": "https://semgrep.dev",
+      "repository_url": "https://github.com/semgrep/semgrep",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "FREEMIUM",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON",
+        "OCAML"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SCALA",
+        "SWIFT",
+        "KOTLIN",
+        "GROOVY",
+        "FORTRAN"
+      ],
+      "_fromFile": "semgrep.json"
+    },
+    {
+      "name": "ShiftLeft Scan",
+      "publisher": "ShiftLeft",
+      "description": "A free open-source security tool for modern DevOps teams that performs static analysis-based security testing across multiple languages and frameworks",
+      "repository_url": "https://github.com/ShiftLeftSecurity/sast-scan",
+      "website_url": "https://www.shiftleft.io/scan/",
+      "capabilities": [],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "PACKAGE_URL"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "shiftleft_scan.json"
+    },
+    {
+      "name": "SnykVulnCheck",
+      "publisher": "Andrii Grytsenko",
+      "description": "Command-line tool that analyzes CycloneDX SBOMs and evaluates components for known vulnerabilities by querying the public Snyk Vulnerability Database API.",
+      "repository_url": "https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck",
+      "website_url": "https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck",
+      "capabilities": [
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "snykvulncheck.json"
+    },
+    {
+      "name": "Socket",
+      "publisher": "Socket",
+      "description": "Supply Chain Security platform. Next-gen SCA + SBOM + 0-day prevention.",
+      "website_url": "https://socket.dev",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "FREEMIUM",
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION",
+        "GITHUB_APP",
+        "GITLAB_CI_TEMPLATE"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "DESIGN",
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [],
+      "supportedLanguages": [
+        "C/C++",
+        ".NET",
+        "ERLANG_ELIXIR",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "KOTLIN",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SCALA",
+        "SWIFT"
+      ],
+      "_fromFile": "socket.json"
+    },
+    {
+      "name": "Software Assurance Guardian Point Man",
+      "publisher": "Reliable Energy Analytics LLC",
+      "description": "A patented tool that performs comprehensive software supply chain risk assessments using a 7-step process to detect vulnerabilities and calculate trustworthiness scores for software.",
+      "website_url": "https://reliableenergyanalytics.com/products",
+      "repository_url": "https://reliableenergyanalytics.com/products",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "software_assurance_guardian_point_man.json"
+    },
+    {
+      "name": "Sonar Cryptography Plugin",
+      "publisher": "IBM",
+      "description": "A SonarQube Plugin that detects cryptographic assets in source code and generates CBOM.",
+      "repository_url": "https://github.com/IBM/sonar-cryptography",
+      "website_url": "https://github.com/IBM/sonar-cryptography",
+      "capabilities": [
+        "CBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "JENKINS_PLUGIN"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "PYTHON"
+      ],
+      "_fromFile": "sonar_cryptography_plugin.json"
+    },
+    {
+      "name": "SonarQube",
+      "publisher": "SonarSource",
+      "description": "SonarQube allows developers and development teams to write clean code and remediate existing code organically, so they can focus on the work they love and maximize the value they generate for businesses.",
+      "repository_url": "https://github.com/SonarSource/sonarqube",
+      "website_url": "https://www.sonarsource.com/products/sonarqube/",
+      "availability": [
+        "OPEN_SOURCE",
+        "FREEMIUM",
+        "COMMERCIAL_LICENSE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "SWIFT",
+        "SCALA",
+        "KOTLIN"
+      ],
+      "_fromFile": "sonarqube.json"
+    },
+    {
+      "name": "SonarQube Advanced Security",
+      "publisher": "Sonar",
+      "description": "Secure your entire codebase\u2014first-party, third-party, and everything in between. Seamlessly integrated into your workflow, SonarQube detects and fixes vulnerabilities, ensures license compliance, and generates Software Bills of Materials",
+      "website_url": "https://sonarsource.com/solutions/security",
+      "capabilities": [
+        "SBOM",
+        "CDXA"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE",
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS",
+        "POLICY_EVALUATION",
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "APPLICATION",
+        "AZURE_PIPELINE_EXTENSION",
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "GITLAB_CI_TEMPLATE",
+        "JENKINS_PLUGIN",
+        "MAVEN_PLUGIN"
+      ],
+      "library": [
+        "JAVA",
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        ".NET",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "KOTLIN",
+        "NODE.JS",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "SCALA"
+      ],
+      "_fromFile": "sonarqube_advanced_security.json"
+    },
+    {
+      "name": "Sonatype Lift",
+      "publisher": "Sonatype",
+      "description": "Cloud-native, collaborative code analysis platform that analyzes pull requests to find and fix security, performance, reliability, and style issues while generating CycloneDX SBOMs.",
+      "website_url": "https://lift.sonatype.com/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE",
+        "FREEMIUM"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [],
+      "packaging": [
+        "GITHUB_APP",
+        "APPLICATION"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON",
+        "GO",
+        "PHP",
+        "RUBY"
+      ],
+      "_fromFile": "sonatype_lift.json"
+    },
+    {
+      "name": "SOOS",
+      "publisher": "SOOS",
+      "description": "Automate your software inventory. SOOS creates, ingests, and manages your Software Bill of Materials and uses patented SCA and the largest open-source SBOM database to find hidden vulnerabilities, license issues, and dependencies sooner.",
+      "website_url": "https://soos.io",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "SUBSCRIPTION",
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "DISTRIBUTE",
+        "TRANSFORM"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_VERSION"
+      ],
+      "packaging": [
+        "GITHUB_ACTION",
+        "GITHUB_APP",
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT",
+        "JAVA",
+        ".NET",
+        "PYTHON",
+        "RUBY",
+        "PHP"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
         "CYCLONEDX_V1.6",
         "CYCLONEDX_V1.5",
         "CYCLONEDX_V1.4"
-      ]
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "JAVA",
+        "PYTHON",
+        "RUBY",
+        "PHP"
+      ],
+      "_fromFile": "soos.json"
+    },
+    {
+      "name": "Spack",
+      "publisher": "Spack",
+      "description": "HPC package manager for Linux and macOS; the spack-sbom plug-in exports CycloneDX SBOMs for any concretized spec.",
+      "repository_url": "https://github.com/spack/spack-sbom",
+      "website_url": "https://spack.io/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "TRANSFORM"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.3"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "FORTRAN",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON",
+        "RUST",
+        "SWIFT"
+      ],
+      "_fromFile": "spack.json"
+    },
+    {
+      "name": "spdxcyclone",
+      "publisher": "SPDX",
+      "description": "Java utility that converts Software Bill of Materials (SBOM) documents from CycloneDX format to SPDX format, supporting multiple serialization options for both standards.",
+      "repository_url": "https://github.com/spdx/cdx2spdx",
+      "website_url": "https://github.com/spdx/cdx2spdx",
+      "capabilities": [],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "TRANSFORM"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "spdxcyclone.json"
+    },
+    {
+      "name": "Spectra Assure",
+      "publisher": "ReversingLabs",
+      "description": "Spectra Assure scans binary software packages, container images, and VM disk images to detect malware, tampering, vulnerabilities, and other exposures. CycloneDX SBOM, SaaSBOM, ML-BOM, and CBOM are outputs.",
+      "repository_url": "https://github.com/reversinglabs/spectra-assure-sdk",
+      "website_url": "https://www.reversinglabs.com/products/software-supply-chain-security",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "CBOM",
+        "AI/ML-BOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "GITLAB_CI_TEMPLATE",
+        "AZURE_PIPELINE_EXTENSION",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CPE",
+        "CYCLONEDX",
+        "PACKAGE_URL",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PYTHON",
+        "PHP",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "spectra_assure.json"
+    },
+    {
+      "name": "SRC:CLR SBOM Generator",
+      "publisher": "Veracode",
+      "description": "Generates a Software Bill of Materials in CycloneDX JSON Format from Veracode SCA Agent results",
+      "repository_url": "https://github.com/veracode/srcclr_sbom_gen",
+      "website_url": "https://github.com/veracode/srcclr_sbom_gen",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "TRANSFORM"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "LIBRARY"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "transform": [
+        "BOM_STANDARD"
+      ],
+      "_fromFile": "src_clr_sbom_generator.json"
+    },
+    {
+      "name": "StackAware",
+      "publisher": "StackAware",
+      "description": "StackAware is a SaaS platform for managing CycloneDX 1.4/1.5 and SPDX SBOMs, enriching them with VEX data, and securely distributing both SBOMs and SaaSBOMs for supply-chain risk analysis.",
+      "website_url": "https://stackaware.com/",
+      "capabilities": [
+        "SBOM",
+        "SAASBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "_fromFile": "stackaware.json"
+    },
+    {
+      "name": "Sunshine",
+      "publisher": "CycloneDX",
+      "description": "Open-source SBOM visualization tool. Converts CycloneDX JSON into interactive charts and tables for components, dependencies, vulnerabilities, and licenses.",
+      "website_url": "https://cyclonedx.github.io/Sunshine/",
+      "repository_url": "https://github.com/CycloneDX/Sunshine/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "library": [
+        "PYTHON"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedLanguages": [
+        "PYTHON"
+      ],
+      "_fromFile": "sunshine.json"
     },
     {
       "name": "Surfactant",
@@ -11321,35 +11833,126 @@
         "JAVASCRIPT/TYPESCRIPT",
         ".NET",
         "PYTHON"
-      ]
+      ],
+      "_fromFile": "surfactant.json"
     },
     {
-      "name": "Chainloop",
-      "publisher": "Chainloop",
-      "description": "Chainloop is an Open Source evidence store for your Software Supply Chain attestations, SBOMs, VEX, QA reports, and more.",
-      "repository_url": "https://github.com/chainloop-dev/chainloop",
-      "website_url": "https://github.com/chainloop-dev/chainloop",
+      "name": "swift-package-sbom-generator",
+      "publisher": "Mattt",
+      "description": "A software bill of materials (SBOM) generator for Swift packages",
+      "repository_url": "https://github.com/mattt/swift-package-sbom",
+      "website_url": "https://github.com/mattt/swift-package-sbom",
       "capabilities": [
-        "SBOM",
-        "VDR/VEX"
+        "SBOM"
       ],
       "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "SWIFT"
+      ],
+      "platform": [
+        "MAC"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "SWIFT"
+      ],
+      "_fromFile": "swift_package_sbom_generator.json"
+    },
+    {
+      "name": "SwiftBOM",
+      "publisher": "CERT Coordination Center (CERT/CC)",
+      "description": "Generates SBOMs for demo and PoC purposes. Supports output in CycloneDX, SPDX, and SWID formats. Visualizes SBOMs as tree graphs.",
+      "repository_url": "https://github.com/CERTCC/SBOM",
+      "website_url": "https://sbom.democert.org/sbom/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
       ],
       "functions": [
         "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "SIGNING/NOTARY"
+        "TRANSFORM"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SWID"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.2"
+      ],
+      "supportedLanguages": [
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "swiftbom.json"
+    },
+    {
+      "name": "Syft",
+      "publisher": "Anchore",
+      "description": "CLI tool and library for generating a Software Bill of Materials from container images and filesystems.",
+      "repository_url": "https://github.com/anchore/syft",
+      "website_url": "https://anchore.github.io/syft/",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "TRANSFORM"
       ],
       "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
+        "RESOURCE_REPORTING",
+        "LICENSE_REPORTING"
       ],
-      "transform": [],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT",
+        "BOM_STANDARD",
+        "BOM_VERSION"
+      ],
       "packaging": [
         "COMMAND_LINE_UTILITY",
+        "LIBRARY",
         "CONTAINER_IMAGE"
       ],
       "library": [
@@ -11363,21 +11966,217 @@
       "lifecycle": [
         "BUILD",
         "POST-BUILD",
-        "OPERATIONS"
+        "DISCOVERY"
       ],
       "supportedStandards": [
         "CYCLONEDX",
         "SPDX"
       ],
       "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
+        "CYCLONEDX_V1.2",
+        "CYCLONEDX_V1.3",
+        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.6"
       ],
       "supportedLanguages": [
+        "C/C++",
         "GO",
         "JAVA",
         "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST"
+      ],
+      "_fromFile": "syft.json"
+    },
+    {
+      "name": "Tally",
+      "publisher": "Jetstack",
+      "description": "Command-line tool that adds OpenSSF Scorecard security posture scores to packages listed in CycloneDX SBOMs.",
+      "repository_url": "https://github.com/jetstack/tally",
+      "website_url": "https://github.com/jetstack/tally",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "POLICY_EVALUATION"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "_fromFile": "tally.json"
+    },
+    {
+      "name": "Technolinator",
+      "publisher": "MediaMarktSaturn Technology",
+      "description": "GitHub App that generates CycloneDX SBOMs with cdxgen, scans them for vulnerabilities using grype, and uploads results to Dependency-Track.",
+      "repository_url": "https://github.com/MediaMarktSaturn/technolinator",
+      "website_url": "https://github.com/MediaMarktSaturn/technolinator",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "GITHUB_APP",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "JAVA"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "_fromFile": "technolinator.json"
+    },
+    {
+      "name": "Tern",
+      "publisher": "Tern",
+      "description": "Software composition analysis tool that generates a Software Bill of Materials for container images and Dockerfiles",
+      "repository_url": "https://github.com/tern-tools/tern",
+      "website_url": "https://github.com/tern-tools/tern",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "RESOURCE_REPORTING"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "library": [
         "PYTHON"
-      ]
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD",
+        "POST-BUILD",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "SPDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "_fromFile": "tern.json"
+    },
+    {
+      "name": "ThreatMapper",
+      "publisher": "Deepfence",
+      "description": "Deepfence ThreatMapper hunts for vulnerabilities in production platforms, ranks vulnerabilities based on their risk-of-exploit using attack path enumeration, and generates CycloneDX SBOMs.",
+      "repository_url": "https://github.com/deepfence/threatmapper",
+      "website_url": "https://deepfence.io/threatmapper",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "CONTAINER_IMAGE",
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "library": [
+        "JAVASCRIPT_TYPESCRIPT"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "threatmapper.json"
     },
     {
       "name": "Threatrix",
@@ -11450,220 +12249,25 @@
         "GROOVY",
         "FORTRAN",
         "NIM"
-      ]
+      ],
+      "_fromFile": "threatrix.json"
     },
     {
-      "name": "cyclonedx_deps_to_mermaid.xsl",
-      "publisher": "Jan Kowalleck",
-      "description": "Extensible Stylesheet Language Transformations (XSLT) to translate CycloneDX dependency graph to mermaid chart.",
-      "repository_url": "https://gist.github.com/jkowalleck/a0f874ee0a8af9a56a0e887631fc53d1",
-      "website_url": "https://gist.github.com/jkowalleck",
+      "name": "Tidelift",
+      "publisher": "Tidelift",
+      "description": "Tidelift provides a managed open-source subscription that delivers commercial support, maintenance, security and license assurances for the open-source dependencies used to build applications, backed directly by project maintainers.",
+      "repository_url": "https://github.com/tidelift",
+      "website_url": "https://tidelift.com/",
       "capabilities": [
         "SBOM"
       ],
       "availability": [
-        "OPEN_SOURCE"
+        "SUBSCRIPTION"
       ],
       "functions": [
-        "TRANSFORM"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "JAVA",
-        "PHP"
-      ]
-    },
-    {
-      "name": "cdx-enrich",
-      "publisher": "Michael Tsfoni",
-      "description": "Enriches a CycloneDX Software Bills of Material (SBOM) with predefined data.",
-      "repository_url": "https://github.com/mtsfoni/cdx-enrich",
-      "website_url": "https://github.com/mtsfoni/cdx-enrich",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "TRANSFORM"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "library": [
-        "C#",
-        ".NET"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "C/C++",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "NODE.JS",
-        "PERL",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SWIFT",
-        "ERLANG_ELIXIR",
-        "SCALA"
-      ]
-    },
-    {
-      "name": "Meta Package Manager",
-      "publisher": "Kevin Deldycke",
-      "description": "Export a SBOM of all packages installed on a Linux, macOS or Windows system.",
-      "repository_url": "https://github.com/kdeldycke/meta-package-manager",
-      "website_url": "https://kdeldycke.github.io/meta-package-manager/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OSI_APPROVED"
-      ],
-      "functions": [
+        "ANALYSIS",
         "AUTHOR",
         "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        ".NET",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "BOMSkope",
-      "publisher": "Netskope",
-      "description": "BOMSkope is a Software Bill of Materials manager designed to streamline the tracking of vendor components. It enables the identification and monitoring of vulnerabilities in vendor software, enhancing visibility into your overall security posture.",
-      "repository_url": "https://github.com/netskopeoss/BOMSkope",
-      "website_url": "https://github.com/netskopeoss/BOMSkope",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": []
-    },
-    {
-      "name": "CVE Scan",
-      "publisher": "The Embedded Kit",
-      "description": "Detect and mitigate vulnerabilities in embedded systems. Generate SBOMs, cross-reference public databases, integrate with CI pipelines, and use filtering/annotations for streamlined security maintenance.",
-      "website_url": "https://theembeddedkit.io/cve-scan-linux-vulnerability-scanner/",
-      "repository_url": "https://theembeddedkit.io/cve-scan-linux-vulnerability-scanner/",
-      "capabilities": [
-        "SBOM",
-        "VDR/VEX"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS"
       ],
       "analysis": [
         "SECURITY_VULNERABILITIES",
@@ -11671,96 +12275,76 @@
         "LICENSE_REPORTING",
         "OUTDATED_COMPONENTS"
       ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "COMMAND_LINE_UTILITY",
+        "GITHUB_ACTION",
+        "GITLAB_CI_TEMPLATE"
+      ],
+      "library": [],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "BUILD"
+      ],
       "supportedStandards": [
         "CYCLONEDX",
         "SPDX"
       ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
+      "cycloneDxVersion": [],
       "supportedLanguages": [
-        "C/C++",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
         "PYTHON",
-        "JAVASCRIPT/TYPESCRIPT"
+        "SWIFT",
+        "GO",
+        "RUST",
+        ".NET",
+        "RUBY",
+        "NODE.JS"
       ],
-      "platform": [
-        "LINUX"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS",
-        "DISCOVERY"
-      ]
+      "_fromFile": "tidelift.json"
     },
     {
-      "name": "nim_lk",
-      "publisher": "Emery Hemingway",
-      "description": "Create and update SBOMs for the Nim programing language. Includes a translation module for the Nimble package manager as well as a Nix expression for building packages from SBOMs.",
-      "repository_url": "https://git.sr.ht/~ehmry/nim_lk",
-      "website_url": "https://git.sr.ht/~ehmry/nim_lk",
+      "name": "Trivy",
+      "publisher": "Aqua Security",
+      "description": "Comprehensive security scanner for containers, filesystems, Git repositories, VMs and Kubernetes that detects vulnerabilities, misconfigurations, secrets and generates CycloneDX SBOMs.",
+      "repository_url": "https://github.com/aquasecurity/trivy",
+      "website_url": "https://trivy.dev/",
       "capabilities": [
-        "SBOM"
+        "SBOM",
+        "VDR/VEX"
       ],
       "availability": [
-        "OPEN_SOURCE"
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
       ],
       "functions": [
+        "ANALYSIS",
         "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
+        "TRANSFORM"
       ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "POLICY_EVALUATION",
+        "RESOURCE_REPORTING"
       ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "NIM"
-      ],
-      "platform": [
-        "LINUX"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ]
-    },
-    {
-      "name": "Bitbucket Pipe for SBOM Generation",
-      "publisher": "ShiftLeftCyber",
-      "description": "Integrate this Bitbucket Pipe into your CI/CD pipeline to automatically generate a Software Bill of Materials (SBOM) for any project.",
-      "repository_url": "https://github.com/shiftleftcyber/syft-bitbucket-pipe",
-      "website_url": "https://shiftleftcyber.io",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "library": [
-        "SHELL"
-      ],
-      "analysis": [],
       "transform": [
         "BOM_STANDARD",
         "BOM_SERIALIZATION_FORMAT"
       ],
       "packaging": [
-        "GITHUB_ACTION",
-        "COMMAND_LINE_UTILITY"
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
+      ],
+      "library": [
+        "GO"
       ],
       "platform": [
         "LINUX",
@@ -11768,16 +12352,17 @@
         "WINDOWS"
       ],
       "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
+        "POST-BUILD",
+        "DISCOVERY",
+        "OPERATIONS"
       ],
       "supportedStandards": [
         "CYCLONEDX",
-        "SPDX"
+        "SPDX",
+        "PACKAGE_URL",
+        "CPE"
       ],
       "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
         "CYCLONEDX_V1.4"
       ],
       "supportedLanguages": [
@@ -11787,217 +12372,19 @@
         "JAVASCRIPT/TYPESCRIPT",
         ".NET",
         "NODE.JS",
-        "PERL",
         "PHP",
         "PYTHON",
         "RUBY",
-        "RUST",
-        "SWIFT",
-        "ERLANG_ELIXIR",
-        "SCALA"
-      ]
+        "RUST"
+      ],
+      "_fromFile": "trivy.json"
     },
     {
-      "name": "Sonar Cryptography Plugin",
-      "publisher": "IBM",
-      "description": "A SonarQube Plugin that detects cryptographic assets in source code and generates CBOM.",
-      "repository_url": "https://github.com/IBM/sonar-cryptography",
-      "website_url": "https://github.com/IBM/sonar-cryptography",
-      "capabilities": [
-        "CBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES"
-      ],
-      "packaging": [
-        "JENKINS_PLUGIN"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "CBOM Viewer",
-      "publisher": "IBM",
-      "description": "A Web Service to visualize and explore the use of cryptography in software with Cryptography Bills of Materials (CBOM).",
-      "website_url": "https://www.zurich.ibm.com/cbom/",
-      "repository_url": "https://www.zurich.ibm.com/cbom/",
-      "capabilities": [
-        "CBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "CBOMkit",
-      "publisher": "IBM",
-      "description": "CBOMkit is a toolset for generating, viewing, checking, and storing Cryptography Bills of Materials (CBOM).",
-      "repository_url": "https://github.com/IBM/cbomkit",
-      "website_url": "https://github.com/IBM/cbomkit",
-      "capabilities": [
-        "CBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "ANALYSIS",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "library": [
-        "JAVA"
-      ],
-      "transform": [
-        "BOM_SERIALIZATION_FORMAT"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "CBOMkit-theia",
-      "publisher": "IBM",
-      "description": "A tool that detects cryptographic assets in container images and directories, generating CBOMs.",
-      "repository_url": "https://github.com/IBM/cbomkit-theia",
-      "website_url": "https://github.com/IBM/cbomkit-theia",
-      "capabilities": [
-        "CBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "RESOURCE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE"
-      ],
-      "library": [
-        "GO"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "Cyberwatch",
-      "publisher": "Cyberwatch",
-      "description": "Cyberwatch Vulnerability Manager allows you to discover assets, scan and prioritize vulnerabilities, and fix them.",
-      "repository_url": "https://cyberwatch.fr/en/",
-      "website_url": "https://cyberwatch.fr/en/",
+      "name": "TrustSource",
+      "publisher": "TrustSource",
+      "description": "SaaS platform for implementing and maintaining open source compliance that imports CycloneDX SBOMs, analyzes them for licenses and vulnerabilities, and integrates with various development workflows.",
+      "repository_url": "https://github.com/trustsource",
+      "website_url": "https://www.trustsource.io/",
       "capabilities": [
         "SBOM",
         "VDR/VEX"
@@ -12007,65 +12394,15 @@
       ],
       "functions": [
         "ANALYSIS",
-        "AUTHOR"
+        "AUTHOR",
+        "TRANSFORM",
+        "PACKAGE_MANAGER_INTEGRATION"
       ],
       "analysis": [
         "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
         "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        ".NET",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "sbomify",
-      "publisher": "sbomify",
-      "description": "sbomify is a comprehensive SBOM management platform that enables secure sharing and analysis of Software Bill of Materials. Seamlessly integrates with CI/CD pipelines.",
-      "website_url": "https://sbomify.com",
-      "repository_url": "https://github.com/sbomify/sbomify",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "DISTRIBUTE",
-        "TRANSFORM"
-      ],
-      "library": [
-        "PYTHON"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
+        "RESOURCE_REPORTING"
       ],
       "transform": [
         "BOM_STANDARD",
@@ -12073,59 +12410,12 @@
       ],
       "packaging": [
         "APPLICATION",
-        "GITHUB_ACTION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT"
-      ]
-    },
-    {
-      "name": "Sunshine",
-      "publisher": "CycloneDX",
-      "description": "Open-source SBOM visualization tool. Converts CycloneDX JSON into interactive charts and tables for components, dependencies, vulnerabilities, and licenses.",
-      "website_url": "https://cyclonedx.github.io/Sunshine/",
-      "repository_url": "https://github.com/CycloneDX/Sunshine/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE"
-      ],
-      "functions": [
-        "ANALYSIS"
+        "COMMAND_LINE_UTILITY"
       ],
       "library": [
-        "PYTHON"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "LICENSE_REPORTING"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
+        "JAVASCRIPT_TYPESCRIPT",
+        "PYTHON",
+        "JAVA"
       ],
       "platform": [
         "LINUX",
@@ -12138,176 +12428,24 @@
         "OPERATIONS",
         "DISCOVERY"
       ],
-      "supportedLanguages": [
-        "PYTHON"
-      ]
-    },
-    {
-      "name": "SOOS",
-      "publisher": "SOOS",
-      "description": "Automate your software inventory. SOOS creates, ingests, and manages your Software Bill of Materials and uses patented SCA and the largest open-source SBOM database to find hidden vulnerabilities, license issues, and dependencies sooner.",
-      "website_url": "https://soos.io",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR",
-        "DISTRIBUTE",
-        "TRANSFORM"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_SERIALIZATION_FORMAT",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "GITHUB_ACTION",
-        "GITHUB_APP",
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ],
-      "library": [
-        "JAVASCRIPT_TYPESCRIPT",
-        "JAVA",
-        ".NET",
-        "PYTHON",
-        "RUBY",
-        "PHP"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
       "supportedStandards": [
         "CYCLONEDX",
-        "PACKAGE_URL",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "JAVA",
-        "PYTHON",
-        "RUBY",
-        "PHP"
-      ]
-    },
-    {
-      "name": "Noma",
-      "publisher": "Noma Security",
-      "description": "AI Application Security Platform for the entire AI lifecycle, focusing on AI asset discovery, ML-BOM, and AI supply chain risk management.",
-      "website_url": "https://noma.security",
-      "capabilities": [
-        "AI/ML-BOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "ANALYSIS",
-        "AUTHOR"
-      ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
-      "transform": [],
-      "packaging": [
-        "APPLICATION"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "DESIGN",
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "JAVA",
-        "C/C++",
-        ".NET",
-        "RUST",
-        "GO"
-      ]
-    },
-    {
-      "name": "RunSafe C/C++ Build-time SBOM Generator",
-      "publisher": "RunSafe Security",
-      "description": "Generates a C/C++ SBOM at build-time without a package manager, working across build environments and reporting on all library dependencies.",
-      "website_url": "https://runsafesecurity.com/c-c-plus-plus-sbom/",
-      "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "packaging": [
-        "GITHUB_ACTION"
-      ],
-      "library": [
-        "C/C++"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
+        "SPDX",
         "PACKAGE_URL"
       ],
       "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3"
+        "CYCLONEDX_V1.6"
       ],
       "supportedLanguages": [
-        "C/C++"
-      ]
+        "C/C++",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PYTHON",
+        "RUBY"
+      ],
+      "_fromFile": "trustsource.json"
     },
     {
       "name": "ts-scan",
@@ -12369,14 +12507,15 @@
         "C/C++",
         "GO",
         ".NET"
-      ]
+      ],
+      "_fromFile": "ts_scan.json"
     },
     {
-      "name": "sbom-validator",
-      "publisher": "ShiftLeftCyber",
-      "description": "A lightweight Go library for validating Software Bill of Materials (SBOM) against industry-standard specifications.",
-      "repository_url": "https://github.com/shiftleftcyber/sbom-validator",
-      "website_url": "https://shiftleftcyber.io",
+      "name": "Valaa Stack",
+      "publisher": "Valaa Technologies",
+      "description": "SBoMDoc is a VDoc extension which uses CycloneDX namespaces and can emit BOM documents in various formats",
+      "repository_url": "https://github.com/valaatech/kernel",
+      "website_url": "https://valospace.org/",
       "capabilities": [
         "SBOM"
       ],
@@ -12384,21 +12523,17 @@
         "OPEN_SOURCE"
       ],
       "functions": [
-        "ANALYSIS"
+        "TRANSFORM"
       ],
-      "analysis": [
-        "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION"
-      ],
+      "analysis": [],
       "transform": [
-        "BOM_STANDARD",
         "BOM_SERIALIZATION_FORMAT"
       ],
       "packaging": [
         "LIBRARY"
       ],
       "library": [
-        "GO"
+        "JAVASCRIPT_TYPESCRIPT"
       ],
       "platform": [
         "LINUX",
@@ -12406,105 +12541,53 @@
         "WINDOWS"
       ],
       "lifecycle": [
-        "BUILD",
-        "POST-BUILD",
-        "OPERATIONS"
+        "BUILD"
       ],
       "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX"
+        "CYCLONEDX"
       ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6",
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4",
-        "CYCLONEDX_V1.3",
-        "CYCLONEDX_V1.2"
-      ],
+      "cycloneDxVersion": [],
       "supportedLanguages": [
-        "GO"
-      ]
+        "JAVASCRIPT/TYPESCRIPT"
+      ],
+      "_fromFile": "valaa_stack.json"
     },
     {
-      "name": "CycloneDX Perl Library",
-      "publisher": "Giuseppe Di Terlizzi",
-      "description": "Perl library for generating CycloneDX SBOMs.",
-      "repository_url": "https://github.com/giterlizzi/perl-SBOM-CycloneDX",
-      "website_url": "https://github.com/giterlizzi/perl-SBOM-CycloneDX",
+      "name": "Valint",
+      "publisher": "Scribe Security",
+      "description": "CLI and CI/CD tool for generating CycloneDX SBOMs, signing and verifying supply-chain evidence, enforcing policy, and tracking vulnerabilities across containers, source repositories, and pipelines.",
+      "repository_url": "https://github.com/scribe-security/gatekeeper-valint",
+      "website_url": "https://scribesecurity.com/scribe-platform-lp",
       "capabilities": [
-        "SBOM"
-      ],
-      "availability": [
-        "OPEN_SOURCE",
-        "OSI_APPROVED"
-      ],
-      "functions": [
-        "AUTHOR"
-      ],
-      "packaging": [
-        "LIBRARY"
-      ],
-      "library": [
-        "PERL"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.3"
-      ],
-      "supportedLanguages": [
-        "PERL"
-      ]
-    },
-    {
-      "name": "ReARM",
-      "publisher": "Reliza",
-      "description": "ReARM is a system to store, organize and manage SBOMs / xBOMs with Component and Product releases.",
-      "repository_url": "https://github.com/relizaio/rearm",
-      "website_url": "https://rearmhq.com",
-      "capabilities": [
-        "AI/ML-BOM",
-        "CBOM",
-        "CDXA",
-        "OBOM",
-        "RELEASE_NOTES",
-        "SAASBOM",
         "SBOM",
         "VDR/VEX"
       ],
       "availability": [
         "OPEN_SOURCE",
         "OSI_APPROVED",
-        "COMMERCIAL_LICENSE"
+        "SUBSCRIPTION"
       ],
       "functions": [
-        "ANALYSIS",
         "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "library": [
-        "JAVA"
+        "ANALYSIS",
+        "SIGNING/NOTARY",
+        "PACKAGE_MANAGER_INTEGRATION",
+        "DISTRIBUTE"
       ],
       "analysis": [
         "SECURITY_VULNERABILITIES",
         "POLICY_EVALUATION",
-        "LICENSE_REPORTING"
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
       ],
       "packaging": [
-        "APPLICATION",
-        "COMMAND_LINE_UTILITY"
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "AZURE_PIPELINE_EXTENSION"
+      ],
+      "library": [
+        "GO"
       ],
       "platform": [
         "LINUX",
@@ -12515,49 +12598,39 @@
         "PRE-BUILD",
         "BUILD",
         "POST-BUILD",
-        "OPERATIONS",
-        "DECOMMISSION"
+        "OPERATIONS"
       ],
       "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
+        "CYCLONEDX"
       ],
       "cycloneDxVersion": [
-        "CYCLONEDX_V1.4",
+        "CYCLONEDX_V1.6",
         "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.6"
+        "CYCLONEDX_V1.4"
       ],
-      "supportedLanguages": [
-        ".NET",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON",
-        "GO",
-        "NODE.JS"
-      ]
+      "_fromFile": "valint.json"
     },
     {
-      "name": "BOMnipotent",
-      "publisher": "Weichwerke Heidrich Software",
-      "description": "A server application for managing and distributing SBOMs and CSAF documents. Integrates with tools for vulnerability scanning.",
-      "website_url": "https://www.bomnipotent.de",
-      "repository_url": "https://github.com/Weichwerke-Heidrich-Software/bomnipotent_doc",
+      "name": "Value Stream Management (VSM)",
+      "publisher": "LeanIX",
+      "description": "SaaS catalog that ingests CycloneDX SBOMs via REST API, indexes them by team and product, and surfaces vulnerabilities, licenses and component age to secure the software supply chain.",
+      "website_url": "https://www.leanix.net/en/products/value-stream-management",
       "capabilities": [
-        "SBOM",
-        "VDR/VEX"
+        "SBOM"
       ],
       "availability": [
+        "SUBSCRIPTION",
         "COMMERCIAL_LICENSE"
       ],
       "functions": [
+        "ANALYSIS",
         "DISTRIBUTE"
       ],
-      "library": [
-        "SHELL"
-      ],
       "analysis": [
-        "SECURITY_VULNERABILITIES"
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS",
+        "POLICY_EVALUATION"
       ],
       "packaging": [
         "APPLICATION"
@@ -12568,211 +12641,172 @@
         "WINDOWS"
       ],
       "lifecycle": [
-        "BUILD",
         "POST-BUILD",
         "OPERATIONS"
       ],
       "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "CPE"
+        "CYCLONEDX"
       ],
       "cycloneDxVersion": [
         "CYCLONEDX_V1.6"
       ],
-      "supportedLanguages": []
+      "_fromFile": "value_stream_management_vsm_.json"
     },
     {
-      "name": "AI SBOM Generator",
-      "publisher": "Aetheris AI",
-      "description": "Generate AI SBOM (AIBOM, AI/ML-BOM) in CycloneDX format for models on Hugging Face.",
-      "repository_url": "https://github.com/aetheris-ai/aibom-generator/",
-      "website_url": "https://sbom.aetheris.ai",
+      "name": "Veracode",
+      "publisher": "Veracode",
+      "description": "API to output SBOM in CycloneDX (JSON) format based on Veracode's software composition analysis (SCA) scan.",
+      "website_url": "https://www.veracode.com/",
       "capabilities": [
-        "AI/ML-BOM"
+        "SBOM",
+        "VDR/VEX"
       ],
       "availability": [
-        "OPEN_SOURCE"
+        "SUBSCRIPTION"
       ],
       "functions": [
+        "ANALYSIS",
         "AUTHOR"
       ],
-      "library": [
-        "PYTHON"
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "transform": [],
+      "packaging": [
+        "APPLICATION",
+        "GITHUB_ACTION"
+      ],
+      "library": [],
+      "platform": [
+        "WINDOWS",
+        "MAC",
+        "LINUX"
       ],
       "lifecycle": [
         "BUILD",
-        "POST-BUILD"
+        "POST-BUILD",
+        "OPERATIONS"
       ],
       "supportedStandards": [
         "CYCLONEDX",
         "PACKAGE_URL"
       ],
       "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "PYTHON",
+        "RUBY",
+        "GO",
+        "PHP"
+      ],
+      "_fromFile": "veracode.json"
+    },
+    {
+      "name": "Vexy",
+      "publisher": "Paul Horton",
+      "description": "Generate VEX (Vulnerability Exploitability Exchange) CycloneDX documents.",
+      "repository_url": "https://github.com/madpah/vexy",
+      "website_url": "https://github.com/madpah/vexy",
+      "capabilities": [
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "transform": [],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "PYTHON"
       ],
       "platform": [
         "LINUX",
         "MAC",
         "WINDOWS"
       ],
-      "packaging": [
-        "COMMAND_LINE_UTILITY",
-        "LIBRARY"
-      ]
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [],
+      "_fromFile": "vexy.json"
     },
     {
-      "name": "ProCap360",
-      "publisher": "Internet Infrastructure Services Corp.",
-      "description": "An advanced SBOM, RBOM and AIBOM  cybersecurity risk management tool using novel knowledge graph technology to enhance software supply chain security and visually display real time application assurance.",
-      "repository_url": "https://github.com/ProCap360",
-      "website_url": "https://procap360.com",
+      "name": "Vigiles",
+      "publisher": "Timesys",
+      "description": "Vulnerability monitoring and remediation suite that imports, generates, converts, and analyses CycloneDX or SPDX SBOMs with curated CVE feeds and build-system integrations for Yocto, Buildroot, OpenWrt, and more.",
+      "repository_url": "https://github.com/TimesysGit/vigiles-cli",
+      "website_url": "https://www.timesys.com/solutions/vigiles-vulnerability-management/",
       "capabilities": [
-        "SBOM",
-        "SAASBOM",
-        "CBOM",
-        "HBOM",
-        "OBOM",
-        "AI/ML-BOM",
-        "VDR/VEX",
-        "CDXA",
-        "RELEASE_NOTES"
+        "SBOM"
       ],
       "availability": [
-        "COMMERCIAL_LICENSE",
         "SUBSCRIPTION"
       ],
       "functions": [
-        "ANALYSIS",
         "AUTHOR",
-        "DISTRIBUTE",
-        "PACKAGE_MANAGER_INTEGRATION",
-        "SIGNING/NOTARY",
-        "TRANSFORM"
+        "ANALYSIS",
+        "DISTRIBUTE"
       ],
       "analysis": [
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS",
-        "POLICY_EVALUATION",
-        "RESOURCE_REPORTING",
         "SECURITY_VULNERABILITIES"
       ],
       "transform": [
-        "BOM_STANDARD",
-        "BOM_VERSION"
+        "BOM_STANDARD"
       ],
       "packaging": [
         "APPLICATION",
-        "AZURE_PIPELINE_EXTENSION"
+        "COMMAND_LINE_UTILITY"
       ],
       "library": [
-        "GO",
-        "JAVASCRIPT_TYPESCRIPT"
+        "PYTHON"
       ],
       "platform": [
         "LINUX",
-        "WINDOWS"
+        "MAC"
       ],
       "lifecycle": [
-        "BUILD",
+        "PRE-BUILD",
         "POST-BUILD",
         "OPERATIONS"
       ],
       "supportedStandards": [
         "CYCLONEDX",
-        "PACKAGE_URL",
         "SPDX"
       ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.5",
-        "CYCLONEDX_V1.4"
-      ],
-      "supportedLanguages": [
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        ".NET",
-        "C/C++"
-      ]
+      "cycloneDxVersion": [],
+      "supportedLanguages": [],
+      "_fromFile": "vigiles.json"
     },
     {
-      "name": "SonarQube Advanced Security",
-      "publisher": "Sonar",
-      "description": "Secure your entire codebase—first-party, third-party, and everything in between. Seamlessly integrated into your workflow, SonarQube detects and fixes vulnerabilities, ensures license compliance, and generates Software Bills of Materials",
-      "repository_url": null,
-      "website_url": "https://sonarsource.com/solutions/security",
-      "capabilities": [
-        "SBOM",
-        "CDXA"
-      ],
-      "availability": [
-        "COMMERCIAL_LICENSE",
-        "SUBSCRIPTION"
-      ],
-      "functions": [
-        "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
-      ],
-      "analysis": [
-        "LICENSE_REPORTING",
-        "OUTDATED_COMPONENTS",
-        "POLICY_EVALUATION",
-        "SECURITY_VULNERABILITIES"
-      ],
-      "transform": [
-        "BOM_STANDARD",
-        "BOM_VERSION"
-      ],
-      "packaging": [
-        "APPLICATION",
-        "AZURE_PIPELINE_EXTENSION",
-        "COMMAND_LINE_UTILITY",
-        "CONTAINER_IMAGE",
-        "GITHUB_ACTION",
-        "GITLAB_CI_TEMPLATE",
-        "JENKINS_PLUGIN",
-        "MAVEN_PLUGIN"
-      ],
-      "library": [
-        "JAVA",
-        "JAVASCRIPT_TYPESCRIPT"
-      ],
-      "platform": [
-        "LINUX",
-        "MAC",
-        "WINDOWS"
-      ],
-      "lifecycle": [
-        "BUILD",
-        "POST-BUILD"
-      ],
-      "supportedStandards": [
-        "CYCLONEDX",
-        "PACKAGE_URL",
-        "SPDX"
-      ],
-      "cycloneDxVersion": [
-        "CYCLONEDX_V1.6"
-      ],
-      "supportedLanguages": [
-        ".NET",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "KOTLIN",
-        "NODE.JS",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SCALA"
-      ]
-    },
-    {
-      "name": "Hermeto",
-      "publisher": "The Hermeto Project",
-      "description": "Hermeto is a CLI tool that pre-fetches your project's dependencies, which enables network-isolated builds, which enables the production of high-accuracy SBOMs",
-      "repository_url": "https://github.com/hermetoproject/hermeto",
-      "website_url": "https://hermetoproject.github.io/hermeto/",
+      "name": "vsm-sbom-booster",
+      "publisher": "LeanIX",
+      "description": "CLI and Docker-based tool that scans Git providers, runs ORT, generates CycloneDX SBOMs centrally, and uploads them to LeanIX VSM to speed onboarding.",
+      "repository_url": "https://github.com/leanix/vsm-sbom-booster",
+      "website_url": "https://github.com/leanix/vsm-sbom-booster",
       "capabilities": [
         "SBOM"
       ],
@@ -12782,42 +12816,171 @@
       ],
       "functions": [
         "AUTHOR",
-        "PACKAGE_MANAGER_INTEGRATION"
+        "PACKAGE_MANAGER_INTEGRATION",
+        "DISTRIBUTE"
       ],
-      "transform": [],
       "packaging": [
         "COMMAND_LINE_UTILITY",
         "CONTAINER_IMAGE"
       ],
-      "library": [],
+      "library": [
+        "KOTLIN"
+      ],
       "platform": [
         "LINUX",
-        "MAC"
+        "MAC",
+        "WINDOWS"
       ],
       "lifecycle": [
-        "PRE-BUILD",
-        "BUILD"
+        "BUILD",
+        "POST-BUILD"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6"
+      ],
+      "supportedLanguages": [
+        "C/C++",
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        ".NET",
+        "NODE.JS",
+        "PHP",
+        "PYTHON",
+        "RUBY",
+        "RUST",
+        "KOTLIN",
+        "SCALA",
+        "SWIFT"
+      ],
+      "_fromFile": "vsm_sbom_booster.json"
+    },
+    {
+      "name": "Vulert Vulnerability Scanner",
+      "publisher": "Vulert.com",
+      "description": "Web SCA service that analyzes CycloneDX or SPDX SBOMs (or lockfiles) to flag open-source vulnerabilities and license issues, sending real-time alerts without requiring code access or signup.",
+      "website_url": "https://vulert.com/abom",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "FREEMIUM"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "APPLICATION"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "POST-BUILD",
+        "OPERATIONS"
       ],
       "supportedStandards": [
         "CYCLONEDX",
-        "SPDX",
-        "SLSA",
-        "PACKAGE_URL"
+        "SPDX"
       ],
-      "supportedLanguages": [
-        "RUBY",
-        "RUST",
-        "GO",
-        "JAVASCRIPT/TYPESCRIPT",
-        "PYTHON"
-      ]
+      "_fromFile": "vulert_vulnerability_scanner.json"
     },
     {
-      "name": "ClickBOM",
-      "publisher": "ClickHouse",
-      "description": "Downloads and merges SBOMs from various sources. Converts to CycloneDX and SPDX formats. Uploads to cloud storage and ClickHouse for analytics.",
-      "repository_url": "https://github.com/ClickHouse/ClickBOM",
-      "website_url": "https://github.com/marketplace/actions/clickbom",
+      "name": "Vulnerabilities.io",
+      "publisher": "Vulnerabilities Input Output Limited",
+      "description": "Generates CycloneDX Software Bill of Materials (SBOM) and visualizations for an organization's codebase through integrations with source control systems. Enables organizations to manage overall supply chain risk.",
+      "website_url": "https://www.vulnerabilities.io",
+      "repository_url": "https://www.vulnerabilities.io",
+      "capabilities": [
+        "SBOM"
+      ],
+      "availability": [
+        "COMMERCIAL_LICENSE"
+      ],
+      "functions": [
+        "ANALYSIS",
+        "AUTHOR",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "LICENSE_REPORTING",
+        "OUTDATED_COMPONENTS"
+      ],
+      "packaging": [
+        "GITHUB_APP",
+        "COMMAND_LINE_UTILITY"
+      ],
+      "supportedLanguages": [
+        "JAVA",
+        ".NET",
+        "PHP",
+        "PYTHON",
+        "JAVASCRIPT/TYPESCRIPT",
+        "RUST",
+        "ERLANG_ELIXIR"
+      ],
+      "_fromFile": "vulnerabilities_io.json"
+    },
+    {
+      "name": "Vuls",
+      "publisher": "Future Corp",
+      "description": "Agent-less vulnerability scanner for Linux, FreeBSD, containers, WordPress, programming language libraries and network devices which outputs CycloneDX Vulnerability Disclosure Reports (VDR).",
+      "repository_url": "https://github.com/future-architect/vuls",
+      "website_url": "https://vuls.io/",
+      "capabilities": [
+        "VDR/VEX"
+      ],
+      "availability": [
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "OPERATIONS",
+        "DISCOVERY"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX"
+      ],
+      "_fromFile": "vuls.json"
+    },
+    {
+      "name": "WpBom",
+      "publisher": "Sepbit",
+      "description": "WordPress plugin that generates CycloneDX SBOMs for installed plugins and themes, and can automatically submit them to OWASP Dependency-Track for vulnerability analysis.",
+      "repository_url": "https://github.com/sepbit/wpbom",
+      "website_url": "https://wordpress.org/plugins/wpbom/",
       "capabilities": [
         "SBOM"
       ],
@@ -12825,44 +12988,122 @@
         "OPEN_SOURCE"
       ],
       "functions": [
-        "ANALYSIS",
+        "AUTHOR",
         "DISTRIBUTE",
-        "TRANSFORM"
+        "PACKAGE_MANAGER_INTEGRATION"
+      ],
+      "analysis": [],
+      "transform": [
+        "BOM_SERIALIZATION_FORMAT"
       ],
       "packaging": [
-        "GITHUB_ACTION"
+        "APPLICATION"
+      ],
+      "library": [
+        "PHP"
       ],
       "platform": [
-        "LINUX"
+        "LINUX",
+        "MAC",
+        "WINDOWS"
       ],
       "lifecycle": [
-        "BUILD",
-        "DISCOVERY",
-        "OPERATIONS",
-        "POST-BUILD"
+        "POST-BUILD",
+        "OPERATIONS"
       ],
       "supportedStandards": [
         "CYCLONEDX",
-        "SPDX"
-      ]
+        "PACKAGE_URL"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.4"
+      ],
+      "supportedLanguages": [
+        "PHP"
+      ],
+      "_fromFile": "wpbom.json"
     },
     {
-      "name": "Aikido Security",
-      "publisher": "Aikido Security",
-      "description": "Code-to-cloud security in one platform—scan, prioritize, and fix issues across the full stack.",
-      "website_url": "https://aikido.dev",
+      "name": "Xray",
+      "publisher": "JFrog",
+      "description": "JFrog Xray is a software-composition-analysis platform that finds vulnerabilities, license issues and policy violations in open-source and third-party components, and can export CycloneDX SBOMs with optional VEX data.",
+      "website_url": "https://jfrog.com/xray/",
       "capabilities": [
         "SBOM",
         "VDR/VEX"
       ],
       "availability": [
         "FREEMIUM",
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
+        "SUBSCRIPTION"
       ],
       "functions": [
         "ANALYSIS",
-        "AUTHOR"
+        "DISTRIBUTE"
+      ],
+      "analysis": [
+        "SECURITY_VULNERABILITIES",
+        "POLICY_EVALUATION",
+        "LICENSE_REPORTING"
+      ],
+      "transform": [
+        "BOM_STANDARD",
+        "BOM_SERIALIZATION_FORMAT"
+      ],
+      "packaging": [
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "AZURE_PIPELINE_EXTENSION"
+      ],
+      "library": [
+        "GO"
+      ],
+      "platform": [
+        "LINUX",
+        "MAC",
+        "WINDOWS"
+      ],
+      "lifecycle": [
+        "PRE-BUILD",
+        "BUILD",
+        "POST-BUILD",
+        "OPERATIONS"
+      ],
+      "supportedStandards": [
+        "CYCLONEDX",
+        "CPE"
+      ],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.5"
+      ],
+      "supportedLanguages": [
+        "GO",
+        "JAVA",
+        "JAVASCRIPT/TYPESCRIPT",
+        "PYTHON",
+        "C/C++",
+        "PHP"
+      ],
+      "_fromFile": "xray.json"
+    },
+    {
+      "name": "Xygeni Software Supply-Chain Security",
+      "publisher": "Xygeni",
+      "description": "Supply-chain security platform and CLI that generates CycloneDX SBOMs, analyses vulnerabilities and misconfigurations, enforces policy in CI/CD, and integrates with DevOps tools to secure releases.",
+      "repository_url": "https://github.com/xygeni/xygeni-action",
+      "website_url": "https://xygeni.io/",
+      "capabilities": [
+        "SBOM",
+        "VDR/VEX"
+      ],
+      "availability": [
+        "SUBSCRIPTION"
+      ],
+      "functions": [
+        "AUTHOR",
+        "ANALYSIS",
+        "DISTRIBUTE",
+        "PACKAGE_MANAGER_INTEGRATION"
       ],
       "analysis": [
         "SECURITY_VULNERABILITIES",
@@ -12870,57 +13111,55 @@
         "LICENSE_REPORTING",
         "OUTDATED_COMPONENTS"
       ],
-      "transform": [],
       "packaging": [
-        "APPLICATION"
+        "COMMAND_LINE_UTILITY",
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION",
+        "JENKINS_PLUGIN"
       ],
-      "library": [],
+      "library": [
+        "JAVA"
+      ],
       "platform": [
         "LINUX",
         "MAC",
         "WINDOWS"
       ],
       "lifecycle": [
-        "DESIGN",
         "PRE-BUILD",
         "BUILD",
-        "POST-BUILD"
+        "POST-BUILD",
+        "OPERATIONS"
       ],
       "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
+        "CYCLONEDX"
       ],
-      "cycloneDxVersion": [],
+      "cycloneDxVersion": [
+        "CYCLONEDX_V1.6",
+        "CYCLONEDX_V1.5",
+        "CYCLONEDX_V1.4"
+      ],
       "supportedLanguages": [
-        "JAVASCRIPT/TYPESCRIPT",
-        "PHP",
         "JAVA",
-        "SWIFT",
-        "GO",
+        "JAVASCRIPT/TYPESCRIPT",
         "PYTHON",
-        ".NET",
-        "RUBY",
-        "RUST",
-        "KOTLIN",
-        "ERLANG_ELIXIR",
-        "C/C++",
-        "SCALA"
-      ]
+        "GO",
+        ".NET"
+      ],
+      "_fromFile": "xygeni_software_supply_chain_security.json"
     },
     {
-      "name": "Socket",
-      "publisher": "Socket",
-      "description": "Supply Chain Security platform. Next-gen SCA + SBOM + 0-day prevention.",
-      "website_url": "https://socket.dev",
+      "name": "yasca (Yet Another SCA tool)",
+      "publisher": "Javi",
+      "description": "Yasca (Yet Another SCA tool) is an open-source Python utility and GitHub Action that scans Maven projects against GitHub Security Advisories, detects vulnerable or outdated dependencies, and exports CycloneDX SBOMs.",
+      "repository_url": "https://github.com/javixeneize/zasca",
+      "website_url": "https://github.com/javixeneize/zasca",
       "capabilities": [
-        "SBOM",
-        "VDR/VEX"
+        "SBOM"
       ],
       "availability": [
-        "FREEMIUM",
-        "SUBSCRIPTION",
-        "COMMERCIAL_LICENSE"
+        "OPEN_SOURCE",
+        "OSI_APPROVED"
       ],
       "functions": [
         "ANALYSIS",
@@ -12929,52 +13168,33 @@
       ],
       "analysis": [
         "SECURITY_VULNERABILITIES",
-        "POLICY_EVALUATION",
-        "LICENSE_REPORTING",
         "OUTDATED_COMPONENTS"
       ],
       "transform": [],
       "packaging": [
-        "APPLICATION",
         "COMMAND_LINE_UTILITY",
-        "GITHUB_ACTION",
-        "GITHUB_APP",
-        "GITLAB_CI_TEMPLATE"
+        "CONTAINER_IMAGE",
+        "GITHUB_ACTION"
       ],
-      "library": [],
+      "library": [
+        "PYTHON"
+      ],
       "platform": [
         "LINUX",
         "MAC",
         "WINDOWS"
       ],
       "lifecycle": [
-        "DESIGN",
-        "PRE-BUILD",
-        "BUILD",
-        "POST-BUILD"
+        "BUILD"
       ],
       "supportedStandards": [
-        "CYCLONEDX",
-        "SPDX",
-        "PACKAGE_URL"
+        "CYCLONEDX"
       ],
       "cycloneDxVersion": [],
       "supportedLanguages": [
-        "C/C++",
-        ".NET",
-        "ERLANG_ELIXIR",
-        "GO",
-        "JAVA",
-        "JAVASCRIPT/TYPESCRIPT",
-        "KOTLIN",
-        "NODE.JS",
-        "PHP",
-        "PYTHON",
-        "RUBY",
-        "RUST",
-        "SCALA",
-        "SWIFT"
-      ]
+        "JAVA"
+      ],
+      "_fromFile": "yasca_yet_another_sca_tool_.json"
     }
   ]
 }

--- a/tools/action_owasp_dependecy_track_check.json
+++ b/tools/action_owasp_dependecy_track_check.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "action-owasp-dependecy-track-check",
+    "publisher": "Quobis",
+    "description": "GitHub Action that builds a CycloneDX SBOM for Node.js, Python, Go, Ruby, Java, .NET and PHP projects, converts it to v1.2 when necessary, and uploads it to an OWASP Dependency-Track server for automatic vulnerability analysis.",
+    "repository_url": "https://github.com/Quobis/action-owasp-dependecy-track-check",
+    "website_url": "https://github.com/Quobis/action-owasp-dependecy-track-check",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "SHELL"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "NODE.JS",
+      "PYTHON",
+      "GO",
+      "RUBY",
+      "JAVA",
+      ".NET",
+      "PHP",
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/ai_sbom_generator.json
+++ b/tools/ai_sbom_generator.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "AI SBOM Generator",
+    "publisher": "Aetheris AI",
+    "description": "Generate AI SBOM (AIBOM, AI/ML-BOM) in CycloneDX format for models on Hugging Face.",
+    "repository_url": "https://github.com/aetheris-ai/aibom-generator/",
+    "website_url": "https://sbom.aetheris.ai",
+    "capabilities": [
+      "AI/ML-BOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ]
+  }
+}

--- a/tools/aikido_security.json
+++ b/tools/aikido_security.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Aikido Security",
+    "publisher": "Aikido Security",
+    "description": "Code-to-cloud security in one platform\u2014scan, prioritize, and fix issues across the full stack.",
+    "website_url": "https://aikido.dev",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "PHP",
+      "JAVA",
+      "SWIFT",
+      "GO",
+      "PYTHON",
+      ".NET",
+      "RUBY",
+      "RUST",
+      "KOTLIN",
+      "ERLANG_ELIXIR",
+      "C/C++",
+      "SCALA"
+    ]
+  }
+}

--- a/tools/amazon_inspector_sbom_generator.json
+++ b/tools/amazon_inspector_sbom_generator.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Amazon Inspector SBOM Generator",
+    "publisher": "Amazon Inspector",
+    "description": "Amazon Inspector SBOM Generator (inspector-sbomgen) outputs CycloneDX 1.4 or SPDX 2.3 SBOMs for archives, container images, directories, local systems, and Go/Rust binaries, providing metadata for vulnerability scans with the Inspector ScanSBOM API.",
+    "website_url": "https://docs.aws.amazon.com/inspector/latest/user/sbom-generator.html",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/apiiro.json
+++ b/tools/apiiro.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Apiiro",
+    "publisher": "Apiiro",
+    "description": "Application Security Posture Management (ASPM) platform that proactively identifies and remediates critical risks in cloud-native applications across the software supply chain.",
+    "website_url": "https://apiiro.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "JAVA",
+      "PYTHON",
+      "GO",
+      ".NET",
+      "RUST"
+    ]
+  }
+}

--- a/tools/apko.json
+++ b/tools/apko.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "apko",
+    "publisher": "Chainguard",
+    "description": "Build OCI images using APK directly without Dockerfile. Generates CycloneDX SBOMs for containers using native SBOM functionality in apk-tools v3.0 and higher.",
+    "repository_url": "https://github.com/chainguard-dev/apko",
+    "website_url": "https://apko.dev/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING",
+      "RESOURCE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "PYTHON",
+      "RUST"
+    ]
+  }
+}

--- a/tools/apt2sbom.json
+++ b/tools/apt2sbom.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "apt2sbom",
+    "publisher": "Eliot Lear",
+    "description": "Python tool that builds a Software Bill of Materials (SBOM) from APT and Python package information on Ubuntu systems, with CLI and HTTP interfaces.",
+    "repository_url": "https://github.com/sbomtools/apt2sbom",
+    "website_url": "https://github.com/sbomtools/apt2sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "PACKAGE_MANAGER_INTEGRATION",
+      "AUTHOR"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "APPLICATION"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/arianna.json
+++ b/tools/arianna.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ARIANNA",
+    "publisher": "Security Pattern",
+    "description": "SBOM, HBOM and vulnerability management platform for intelligent connect devices. Show compliance to regulations and standards and manage risk across the entire product lifecycle.",
+    "website_url": "https://www.securitypattern.com/arianna-security-management-platform",
+    "capabilities": [
+      "SBOM",
+      "HBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CPE",
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "PYTHON",
+      "PHP"
+    ]
+  }
+}

--- a/tools/arnica.json
+++ b/tools/arnica.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Arnica",
+    "publisher": "Arnica",
+    "description": "SaaS platform that automates software supply-chain security; offers free, always-up-to-date SBOM generation in CycloneDX format plus risk analysis and CI/CD integrations.",
+    "website_url": "https://www.arnica.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/arsenal.json
+++ b/tools/arsenal.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Arsenal",
+    "publisher": "Deepbits",
+    "description": "Free online toolset that builds AI-powered SBOMs and SaaSBOMs for COTS, OSS, code repos and container images, then analyzes vulnerabilities, licenses and outdated components to surface software-supply-chain risk.",
+    "website_url": "https://tools.deepbits.com/",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/asdf_cyclonedx.json
+++ b/tools/asdf_cyclonedx.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "asdf-cyclonedx",
+    "publisher": "Xeed.IO, LLC",
+    "description": "asdf plugin that installs and manages CycloneDX CLI versions, enabling SBOM tooling in any asdf-managed environment.",
+    "repository_url": "https://github.com/xeedio/asdf-cyclonedx",
+    "website_url": "https://github.com/xeedio/asdf-cyclonedx",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "SHELL"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5"
+    ]
+  }
+}

--- a/tools/athena.json
+++ b/tools/athena.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Athena",
+    "publisher": "Medical Aegis Inc",
+    "description": "Athena is a SaaS solution for medical device makers that overlays the product development lifecycle to address risks before devices go to market.",
+    "repository_url": "https://github.com/anquanscan/sec-tools",
+    "website_url": "https://medicalaegis.com",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "GITHUB_APP",
+      "GITLAB_CI_TEMPLATE",
+      "JENKINS_PLUGIN",
+      "MAVEN_PLUGIN"
+    ],
+    "library": [
+      "JAVA",
+      "JAVASCRIPT_TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT",
+      "ERLANG_ELIXIR",
+      "SCALA",
+      "KOTLIN",
+      "GROOVY",
+      "FORTRAN"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY",
+      "DECOMMISSION"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "CPE",
+      "OMNIBOR",
+      "SWID",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT",
+      "ERLANG_ELIXIR",
+      "SCALA",
+      "KOTLIN",
+      "GROOVY",
+      "FORTRAN"
+    ]
+  }
+}

--- a/tools/auditjs.json
+++ b/tools/auditjs.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Auditjs",
+    "publisher": "Sonatype",
+    "description": "Audits JavaScript projects to identify known vulnerabilities and outdated package versions using the OSS Index v3 REST API",
+    "repository_url": "https://github.com/sonatype-nexus-community/auditjs",
+    "website_url": "https://github.com/sonatype-nexus-community/auditjs",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/beniva_software_bill_of_materials_sbom_.json
+++ b/tools/beniva_software_bill_of_materials_sbom_.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Beniva Software Bill of Materials (SBOM)",
+    "publisher": "Beniva",
+    "description": "Beniva SBOM allows you to consume CycloneDX SBOM and Vulnerability Exploitability eXchange (VEX) within the ServiceNow platform which increases visibility of vulnerabilities and reduces time to remediate.",
+    "website_url": "https://store.servicenow.com/sn_appstore_store.do#!/store/application/1f62663a1ba19dd06921a821604bcb98",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "lifecycle": [
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/bitbucket_pipe_for_sbom_generation.json
+++ b/tools/bitbucket_pipe_for_sbom_generation.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Bitbucket Pipe for SBOM Generation",
+    "publisher": "ShiftLeftCyber",
+    "description": "Integrate this Bitbucket Pipe into your CI/CD pipeline to automatically generate a Software Bill of Materials (SBOM) for any project.",
+    "repository_url": "https://github.com/shiftleftcyber/syft-bitbucket-pipe",
+    "website_url": "https://shiftleftcyber.io",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "library": [
+      "SHELL"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "GITHUB_ACTION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT",
+      "ERLANG_ELIXIR",
+      "SCALA"
+    ]
+  }
+}

--- a/tools/black_duck.json
+++ b/tools/black_duck.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Black Duck",
+    "publisher": "Synopsys",
+    "description": "Black Duck is Synopsys\u2019 SCA platform that generates CycloneDX/SPDX SBOMs, detects open-source vulnerabilities, and automates license and policy compliance across applications, containers and CI/CD pipelines.",
+    "repository_url": "https://github.com/blackducksoftware/detect",
+    "website_url": "https://www.synopsys.com/software-integrity/security-testing/software-composition-analysis.html",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "AZURE_PIPELINE_EXTENSION",
+      "JENKINS_PLUGIN",
+      "APPLICATION"
+    ],
+    "library": [
+      "JAVA",
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL",
+      "CPE"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT",
+      "ERLANG_ELIXIR",
+      "SCALA",
+      "KOTLIN"
+    ]
+  }
+}

--- a/tools/blackberry_jarvis.json
+++ b/tools/blackberry_jarvis.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "BlackBerry Jarvis",
+    "publisher": "BlackBerry",
+    "description": "Software composition analysis (SCA) and security testing solution that detects and lists open-source software and licenses in embedded systems and their cybersecurity vulnerabilities and exposures.",
+    "website_url": "https://blackberry.qnx.com/en/products/security/blackberry-jarvis",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [
+      "C/C++",
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "JAVA"
+    ]
+  }
+}

--- a/tools/bogrod.json
+++ b/tools/bogrod.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "bogrod",
+    "publisher": "productaize",
+    "description": "A command line tool to manage SBOM and VEX like source code and to distribute SBOMs to notaries.",
+    "repository_url": "https://github.com/productaize/bogrod",
+    "website_url": "https://github.com/productaize/bogrod",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/bom_repository_server.json
+++ b/tools/bom_repository_server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "BOM Repository Server",
+    "publisher": "CycloneDX",
+    "description": "A lightweight repository server used to publish, manage, and distribute CycloneDX SBOMs.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-bom-repo-server",
+    "website_url": "https://github.com/CycloneDX/cyclonedx-bom-repo-server",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "CONTAINER_IMAGE"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ]
+  }
+}

--- a/tools/bomber.json
+++ b/tools/bomber.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "bomber",
+    "publisher": "DevOps Kung Fu Mafia",
+    "description": "CLI scanner that analyses CycloneDX, SPDX or Syft SBOMs for security vulnerabilities and licence issues using OSV, Sonatype OSS Index, GitHub Advisory or Snyk providers.",
+    "repository_url": "https://github.com/devops-kung-fu/bomber",
+    "website_url": "https://github.com/devops-kung-fu/bomber",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/bombon.json
+++ b/tools/bombon.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "bombon",
+    "publisher": "nikstur",
+    "description": "CLI and Nix library that generates CycloneDX v1.5 SBOMs for Nix packages, including build-time and vendored dependencies, compliant with BSI TR-03183 and US EO 14028.",
+    "repository_url": "https://github.com/nikstur/bombon",
+    "website_url": "https://github.com/nikstur/bombon",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "LIBRARY",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "RUST"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3"
+    ]
+  }
+}

--- a/tools/bomnipotent.json
+++ b/tools/bomnipotent.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "BOMnipotent",
+    "publisher": "Weichwerke Heidrich Software",
+    "description": "A server application for managing and distributing SBOMs and CSAF documents. Integrates with tools for vulnerability scanning.",
+    "website_url": "https://www.bomnipotent.de",
+    "repository_url": "https://github.com/Weichwerke-Heidrich-Software/bomnipotent_doc",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "library": [
+      "SHELL"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "CPE"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/bomskope.json
+++ b/tools/bomskope.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "BOMSkope",
+    "publisher": "Netskope",
+    "description": "BOMSkope is a Software Bill of Materials manager designed to streamline the tracking of vendor components. It enables the identification and monitoring of vulnerabilities in vendor software, enhancing visibility into your overall security posture.",
+    "repository_url": "https://github.com/netskopeoss/BOMSkope",
+    "website_url": "https://github.com/netskopeoss/BOMSkope",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/build_info_go.json
+++ b/tools/build_info_go.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "build-info-go",
+    "publisher": "JFrog",
+    "description": "Open-source Go library and CLI that captures build metadata and outputs CycloneDX SBOMs for Java, Node.js, .NET, Go, Python and more.",
+    "repository_url": "https://github.com/jfrog/build-info-go",
+    "website_url": "https://github.com/jfrog/build-info-go",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/bytesafe.json
+++ b/tools/bytesafe.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Bytesafe",
+    "publisher": "Bytesafe",
+    "description": "Bytesafe is a dependency firewall and SCA platform that blocks malicious packages, scans for vulnerabilities, enforces license policies, and generates CycloneDX SBOMs to secure the software supply chain.",
+    "repository_url": "https://github.com/bitfront-se/bytesafe-ce",
+    "website_url": "https://bytesafe.dev/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "FREEMIUM",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/capycli_clearing_automation_for_sw360.json
+++ b/tools/capycli_clearing_automation_for_sw360.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CaPyCli - Clearing Automation for SW360",
+    "publisher": "Siemens",
+    "description": "CaPyCli is an MIT-licensed Python CLI that generates, compares, merges and converts CycloneDX SBOMs for several language ecosystems and maps them to a SW360 component database.",
+    "repository_url": "https://github.com/sw360/capycli",
+    "website_url": "https://github.com/sw360/capycli",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/cast_highlight.json
+++ b/tools/cast_highlight.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CAST Highlight",
+    "publisher": "CAST",
+    "description": "CAST Highlight automatically analyzes source code portfolios for open-source risks, cloud readiness, resiliency, green impact and technical debt, and can import CycloneDX SBOMs for instant SCA insights.",
+    "website_url": "https://www.castsoftware.com/products/highlight",
+    "repository_url": "https://github.com/MichaelMULLER/highlight-scan-github-action",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      ".NET",
+      "NODE.JS",
+      "JAVASCRIPT/TYPESCRIPT",
+      "C/C++",
+      "GO",
+      "PYTHON",
+      "PHP",
+      "RUBY",
+      "SCALA",
+      "KOTLIN"
+    ]
+  }
+}

--- a/tools/cast_sbom_manager.json
+++ b/tools/cast_sbom_manager.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CAST SBOM Manager",
+    "publisher": "CAST",
+    "description": "CAST SBOM Manager automates creation, customization and maintenance of SBOMs, adds vulnerability and license insights, and exports them in CycloneDX, Excel and Word with a free tier up to 25 SBOMs.",
+    "website_url": "https://www.castsoftware.com/sbommanager",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "FREEMIUM"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "DISTRIBUTE",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/cbom_viewer.json
+++ b/tools/cbom_viewer.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CBOM Viewer",
+    "publisher": "IBM",
+    "description": "A Web Service to visualize and explore the use of cryptography in software with Cryptography Bills of Materials (CBOM).",
+    "website_url": "https://www.zurich.ibm.com/cbom/",
+    "repository_url": "https://www.zurich.ibm.com/cbom/",
+    "capabilities": [
+      "CBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/cbomkit.json
+++ b/tools/cbomkit.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CBOMkit",
+    "publisher": "IBM",
+    "description": "CBOMkit is a toolset for generating, viewing, checking, and storing Cryptography Bills of Materials (CBOM).",
+    "repository_url": "https://github.com/IBM/cbomkit",
+    "website_url": "https://github.com/IBM/cbomkit",
+    "capabilities": [
+      "CBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/cbomkit_theia.json
+++ b/tools/cbomkit_theia.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CBOMkit-theia",
+    "publisher": "IBM",
+    "description": "A tool that detects cryptographic assets in container images and directories, generating CBOMs.",
+    "repository_url": "https://github.com/IBM/cbomkit-theia",
+    "website_url": "https://github.com/IBM/cbomkit-theia",
+    "capabilities": [
+      "CBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/cdx_central.json
+++ b/tools/cdx_central.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cdx-central",
+    "publisher": "nscuro",
+    "description": "CLI utility that downloads public CycloneDX SBOMs from Maven Central for selected artifacts.",
+    "repository_url": "https://github.com/nscuro/cdx-central",
+    "website_url": "https://github.com/nscuro/cdx-central",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "analysis": [],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/cdx_enrich.json
+++ b/tools/cdx_enrich.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cdx-enrich",
+    "publisher": "Michael Tsfoni",
+    "description": "Enriches a CycloneDX Software Bills of Material (SBOM) with predefined data.",
+    "repository_url": "https://github.com/mtsfoni/cdx-enrich",
+    "website_url": "https://github.com/mtsfoni/cdx-enrich",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "C#",
+      ".NET"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT",
+      "ERLANG_ELIXIR",
+      "SCALA"
+    ]
+  }
+}

--- a/tools/cdx_vs_cdx.json
+++ b/tools/cdx_vs_cdx.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cdx-vs-cdx",
+    "publisher": "marcosanchotene",
+    "description": "GTK-style Python GUI that compares two CycloneDX JSON SBOMs, highlighting components unique to each file and those present in both.",
+    "repository_url": "https://github.com/marcosanchotene/cdx-vs-cdx",
+    "website_url": "https://github.com/marcosanchotene/cdx-vs-cdx",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/cdxgen.json
+++ b/tools/cdxgen.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cdxgen",
+    "publisher": "CycloneDX",
+    "description": "Universal polyglot CLI, library and server that generates CycloneDX SBOMs\u2014including SaaSBOM, OBOM and CBOM variants\u2014for source code, container images and cloud resources.",
+    "repository_url": "https://github.com/CycloneDX/cdxgen",
+    "website_url": "https://cyclonedx.github.io/cdxgen/",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "CBOM",
+      "OBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "SIGNING/NOTARY"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "NODE.JS"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/chainloop.json
+++ b/tools/chainloop.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Chainloop",
+    "publisher": "Chainloop",
+    "description": "Chainloop is an Open Source evidence store for your Software Supply Chain attestations, SBOMs, VEX, QA reports, and more.",
+    "repository_url": "https://github.com/chainloop-dev/chainloop",
+    "website_url": "https://github.com/chainloop-dev/chainloop",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "SIGNING/NOTARY"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/checkov.json
+++ b/tools/checkov.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Checkov",
+    "publisher": "Checkov",
+    "description": "Prevent cloud misconfigurations during build-time for Terraform, Cloudformation, Kubernetes, Serverless framework and other infrastructure-as-code-languages with Checkov by Bridgecrew. Can output to CycloneDX.",
+    "repository_url": "https://github.com/bridgecrewio/checkov",
+    "website_url": "https://www.checkov.io/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "platform": [
+      "WINDOWS",
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "PRE-BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/chelsea.json
+++ b/tools/chelsea.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Chelsea",
+    "publisher": "Sonatype",
+    "description": "Dependency vulnerability auditor for Ruby",
+    "repository_url": "https://github.com/sonatype-nexus-community/chelsea",
+    "website_url": "https://github.com/sonatype-nexus-community/chelsea",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "RUBY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "RUBY"
+    ]
+  }
+}

--- a/tools/clickbom.json
+++ b/tools/clickbom.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ClickBOM",
+    "publisher": "ClickHouse",
+    "description": "Downloads and merges SBOMs from various sources. Converts to CycloneDX and SPDX formats. Uploads to cloud storage and ClickHouse for analytics.",
+    "repository_url": "https://github.com/ClickHouse/ClickBOM",
+    "website_url": "https://github.com/marketplace/actions/clickbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE",
+      "TRANSFORM"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "DISCOVERY",
+      "OPERATIONS",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/codenotary_cas.json
+++ b/tools/codenotary_cas.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CodeNotary CAS",
+    "publisher": "CodeNotary",
+    "description": "CAS is an open source attestation service for the community. Notarize and authorize files, directories, git repos and Build SBOMs of containers.",
+    "repository_url": "https://github.com/codenotary/cas",
+    "website_url": "https://cas.codenotary.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "SIGNING/NOTARY",
+      "AUTHOR"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/codenotary_cas_authenticate_docker_image_and_sbom.json
+++ b/tools/codenotary_cas_authenticate_docker_image_and_sbom.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Codenotary CAS Authenticate Docker Image and SBOM",
+    "publisher": "Codenotary",
+    "description": "A GitHub Action which authenticates notarized Docker images and SBOMs.",
+    "repository_url": "https://github.com/codenotary/cas-authenticate-docker-bom-github-action",
+    "website_url": "https://cas.codenotary.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "SIGNING/NOTARY"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/codenotary_cas_notarize_docker_image_and_sbom.json
+++ b/tools/codenotary_cas_notarize_docker_image_and_sbom.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Codenotary CAS Notarize Docker Image and SBOM",
+    "publisher": "Codenotary",
+    "description": "A GitHub Action which notarizes and creates an SBOM for Docker images.",
+    "repository_url": "https://github.com/codenotary/cas-notarize-docker-image-bom-github-action",
+    "website_url": "https://cas.codenotary.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "SIGNING/NOTARY",
+      "AUTHOR"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/codenotary_vcn.json
+++ b/tools/codenotary_vcn.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Codenotary vcn",
+    "publisher": "Codenotary",
+    "description": "Protects an organization's software development pipeline from supply chain attacks. Codenotary natively supports CycloneDX SBOMs.",
+    "repository_url": "https://github.com/codenotary/vcn",
+    "website_url": "https://codenotary.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "SIGNING/NOTARY"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/codesentry.json
+++ b/tools/codesentry.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CodeSentry",
+    "publisher": "GrammaTech",
+    "description": "Software Composition Analysis (SCA) platform that leverages binary analysis to identify components, inherited risk, and communicates inventory through CycloneDX SBOMs",
+    "website_url": "https://www.grammatech.com",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/continuous_clearing.json
+++ b/tools/continuous_clearing.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Continuous Clearing",
+    "publisher": "Siemens",
+    "description": "Scans third-party OSS components in NPM, NuGet, Maven, Python and Debian projects, generates CycloneDX SBOMs, then uploads them to SW360 and Fossology for automated license clearing.",
+    "repository_url": "https://github.com/siemens/continuous-clearing",
+    "website_url": "https://github.com/siemens/continuous-clearing",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      ".NET"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/contrast_security.json
+++ b/tools/contrast_security.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Contrast Security",
+    "publisher": "Contrast Security",
+    "description": "Automatically generates component inventory from runtime analysis (IAST or RASP) and generates CycloneDX SBOMs",
+    "website_url": "https://www.contrastsecurity.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "LIBRARY",
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS",
+      ".NET",
+      "PYTHON",
+      "GO",
+      "PHP",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/cosign.json
+++ b/tools/cosign.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Cosign",
+    "publisher": "Sigstore",
+    "description": "Container Signing, Verification and Storage in an OCI registry, including CycloneDX SBOMs",
+    "repository_url": "https://github.com/sigstore/cosign",
+    "website_url": "https://sigstore.dev/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "SIGNING/NOTARY",
+      "AUTHOR",
+      "DISTRIBUTE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ]
+  }
+}

--- a/tools/covenant.json
+++ b/tools/covenant.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Covenant",
+    "publisher": "Patrik Svensson",
+    "description": "Command-line tool that creates SBOMs from .NET and NPM projects or existing CycloneDX BOMs, outputting CycloneDX or SPDX formats.",
+    "repository_url": "https://github.com/patriksvensson/covenant",
+    "website_url": "https://github.com/patriksvensson/covenant",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      ".NET"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "supportedLanguages": [
+      ".NET",
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS"
+    ]
+  }
+}

--- a/tools/cve_bin_tool.json
+++ b/tools/cve_bin_tool.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cve-bin-tool",
+    "publisher": "Intel",
+    "description": "Command-line scanner that identifies vulnerable components in binaries, accepts/generates SBOMs, and reports CVEs. Supports 400+ checkers for open source libraries with CycloneDX output.",
+    "repository_url": "https://github.com/intel/cve-bin-tool",
+    "website_url": "https://cve-bin-tool.readthedocs.io/en/latest/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "CPE",
+      "SPDX",
+      "SWID"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "PYTHON",
+      "JAVASCRIPT/TYPESCRIPT",
+      "ERLANG_ELIXIR",
+      "GO",
+      "RUST"
+    ]
+  }
+}

--- a/tools/cve_scan.json
+++ b/tools/cve_scan.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CVE Scan",
+    "publisher": "The Embedded Kit",
+    "description": "Detect and mitigate vulnerabilities in embedded systems. Generate SBOMs, cross-reference public databases, integrate with CI pipelines, and use filtering/annotations for streamlined security maintenance.",
+    "website_url": "https://theembeddedkit.io/cve-scan-linux-vulnerability-scanner/",
+    "repository_url": "https://theembeddedkit.io/cve-scan-linux-vulnerability-scanner/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "PYTHON",
+      "JAVASCRIPT/TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ]
+  }
+}

--- a/tools/cxsca.json
+++ b/tools/cxsca.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CxSCA",
+    "publisher": "Checkmarx",
+    "description": "Software Composition Analysis (SCA) platform that identifies vulnerabilities, malicious code, and license risks in open-source libraries with exploitable path analysis and SBOM generation capabilities.",
+    "website_url": "https://checkmarx.com/cxsca-open-source-scanning/",
+    "repository_url": "https://checkmarx.com/cxsca-open-source-scanning/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE",
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/cybeats_sbom_studio.json
+++ b/tools/cybeats_sbom_studio.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Cybeats SBOM Studio",
+    "publisher": "Cybeats Technologies Inc.",
+    "description": "Enterprise solution to manage SBOMs at scale and proactively discover and reduce risk across the entire software supply chain, from development through deployment.",
+    "repository_url": "https://github.com/cybeats",
+    "website_url": "https://www.cybeats.com/product/sbom-studio",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "TRANSFORM",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/cybellum_sbom.json
+++ b/tools/cybellum_sbom.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Cybellum SBOM",
+    "publisher": "Cybellum Technologies LTD.",
+    "description": "Analyzes binary artifacts to generate SBOMs including context-based analysis to perform accurate vulnerability assessment",
+    "website_url": "https://cybellum.com",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/cyberwatch.json
+++ b/tools/cyberwatch.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Cyberwatch",
+    "publisher": "Cyberwatch",
+    "description": "Cyberwatch Vulnerability Manager allows you to discover assets, scan and prioritize vulnerabilities, and fix them.",
+    "repository_url": "https://cyberwatch.fr/en/",
+    "website_url": "https://cyberwatch.fr/en/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      ".NET",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/cyclonedx_buildroot.json
+++ b/tools/cyclonedx_buildroot.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX-Buildroot",
+    "publisher": "CycloneDX",
+    "description": "Python application that generates CycloneDX Software Bill of Materials (SBOM) for Buildroot-generated projects and other projects with CSV manifest files",
+    "repository_url": "https://github.com/cyclonedx/cyclonedx-buildroot",
+    "website_url": "https://pypi.org/project/cyclonedx-buildroot/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++"
+    ]
+  }
+}

--- a/tools/cyclonedx_cli.json
+++ b/tools/cyclonedx_cli.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX CLI",
+    "publisher": "CycloneDX",
+    "description": "CLI tool for SBOM analysis, merging, diffs, format conversions, signing, and validation. Supports CycloneDX XML/JSON/Protobuf/CSV, SPDX JSON, and more.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-cli",
+    "website_url": "https://cyclonedx.org/",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "OBOM",
+      "MBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM",
+      "SIGNING/NOTARY"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      ".NET"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/cyclonedx_core_for_java.json
+++ b/tools/cyclonedx_core_for_java.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX Core for Java",
+    "publisher": "OWASP Foundation (CycloneDX Project)",
+    "description": "Java library for creating, parsing, and validating CycloneDX SBOMs.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-core-java",
+    "website_url": "https://cyclonedx.github.io/cyclonedx-core-java/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "JAVA"
+    ]
+  }
+}

--- a/tools/cyclonedx_deps_to_mermaid_xsl.json
+++ b/tools/cyclonedx_deps_to_mermaid_xsl.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cyclonedx_deps_to_mermaid.xsl",
+    "publisher": "Jan Kowalleck",
+    "description": "Extensible Stylesheet Language Transformations (XSLT) to translate CycloneDX dependency graph to mermaid chart.",
+    "repository_url": "https://gist.github.com/jkowalleck/a0f874ee0a8af9a56a0e887631fc53d1",
+    "website_url": "https://gist.github.com/jkowalleck",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "JAVA",
+      "PHP"
+    ]
+  }
+}

--- a/tools/cyclonedx_editor_validator.json
+++ b/tools/cyclonedx_editor_validator.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cyclonedx-editor-validator",
+    "publisher": "Festo SE & Co. KG",
+    "description": "Command-line utility to create, merge, edit and validate CycloneDX SBOMs and VEX files for automated CI/CD workflows.",
+    "repository_url": "https://github.com/Festo-se/cyclonedx-editor-validator",
+    "website_url": "https://festo-se.github.io/cyclonedx-editor-validator/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/cyclonedx_enrich.json
+++ b/tools/cyclonedx_enrich.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cyclonedx-enrich",
+    "publisher": "fnxpt",
+    "description": "Enrich CycloneDX SBOM files by applying enrichers to improve data quality, including licenses, hashes, properties, and references.",
+    "repository_url": "https://github.com/fnxpt/cyclonedx-enrich",
+    "website_url": "https://github.com/fnxpt/cyclonedx-enrich",
+    "capabilities": [
+      "SBOM",
+      "CBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_bower.json
+++ b/tools/cyclonedx_for_bower.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Bower",
+    "publisher": "Hans Thorhauge Dam",
+    "description": "Creates CycloneDX Software Bill of Materials (SBOM) from JavaScript projects that manage dependencies with Bower.",
+    "repository_url": "https://github.com/hanstdam/cdx-bower-bom",
+    "website_url": "https://www.npmjs.com/package/cdx-bower-bom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_cocoapods.json
+++ b/tools/cyclonedx_for_cocoapods.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Cocoapods",
+    "publisher": "CycloneDX",
+    "description": "Creates CycloneDX SBOMs for Objective-C and Swift projects that use CocoaPods.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-cocoapods",
+    "website_url": "https://github.com/CycloneDX/cyclonedx-cocoapods",
+    "capabilities": [
+      "SBOM",
+      "OBOM",
+      "MBOM",
+      "SAASBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "RUBY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_conan1.json
+++ b/tools/cyclonedx_for_conan1.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Conan1",
+    "publisher": "CycloneDX",
+    "description": "Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects using Conan1 (note: considered deprecated)",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-conan",
+    "website_url": "https://pypi.org/project/cyclonedx-conan/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "platform": [
+      "WINDOWS",
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "supportedLanguages": [
+      "C/C++"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_conan2.json
+++ b/tools/cyclonedx_for_conan2.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Conan2",
+    "publisher": "Conan-IO",
+    "description": "Creates CycloneDX Software Bill of Materials (SBOM) for C/C++ projects using Conan2",
+    "repository_url": "https://github.com/conan-io/conan-extensions",
+    "website_url": "https://github.com/conan-io/conan-extensions/tree/main/extensions/commands/sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "packaging": [
+      "CONAN_EXTENSION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "platform": [
+      "WINDOWS",
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.1",
+      "CYCLONEDX_V1.0"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "supportedLanguages": [
+      "C/C++"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_erlang_elixir_mix_.json
+++ b/tools/cyclonedx_for_erlang_elixir_mix_.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Erlang/Elixir (Mix)",
+    "publisher": "Bram Verburg",
+    "description": "Mix task that generates CycloneDX SBOMs for Erlang/Elixir projects, exporting XML or JSON and supporting multiple CycloneDX schema versions.",
+    "repository_url": "https://github.com/voltone/sbom",
+    "website_url": "https://hex.pm/packages/sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "ERLANG_ELIXIR"
+    ],
+    "library": [
+      "ERLANG_ELIXIR"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_erlang_elixir_rebar3_.json
+++ b/tools/cyclonedx_for_erlang_elixir_rebar3_.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Erlang/Elixir (Rebar3)",
+    "publisher": "Bram Verburg",
+    "description": "Rebar3 plug-in that generates CycloneDX SBOMs for Erlang/Elixir projects, exporting XML or JSON and supporting CycloneDX v1.4.",
+    "repository_url": "https://github.com/voltone/rebar3_sbom",
+    "website_url": "https://hex.pm/packages/rebar3_sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "ERLANG_ELIXIR"
+    ],
+    "library": [
+      "ERLANG_ELIXIR"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_go.json
+++ b/tools/cyclonedx_for_go.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Go",
+    "publisher": "Ozon",
+    "description": "Command-line utility and Go library that generates CycloneDX SBOMs from Go module projects for supply-chain transparency.",
+    "repository_url": "https://github.com/ozonru/cyclonedx-go",
+    "website_url": "https://github.com/ozonru/cyclonedx-go",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_go_modules.json
+++ b/tools/cyclonedx_for_go_modules.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Go modules",
+    "publisher": "OWASP Foundation \u2013 CycloneDX Project",
+    "description": "Command-line utility and Go library that generates CycloneDX SBOMs from Go modules, binaries and applications.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-gomod",
+    "website_url": "https://github.com/CycloneDX/cyclonedx-gomod",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_gradle.json
+++ b/tools/cyclonedx_for_gradle.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Gradle",
+    "publisher": "CycloneDX",
+    "description": "Gradle plugin that generates CycloneDX SBOMs (XML or JSON) for all dependencies in Java-based builds.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-gradle-plugin",
+    "website_url": "https://plugins.gradle.org/plugin/org.cyclonedx.bom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "JAVA"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_maven.json
+++ b/tools/cyclonedx_for_maven.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Maven",
+    "publisher": "OWASP Foundation / CycloneDX Project",
+    "description": "Apache Maven plugin that automatically generates CycloneDX SBOMs (JSON or XML) for Java projects and can attach vulnerability disclosure information.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-maven-plugin",
+    "website_url": "https://github.com/CycloneDX/cyclonedx-maven-plugin",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "CPE"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "JAVA"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_net.json
+++ b/tools/cyclonedx_for_net.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for .NET",
+    "publisher": "CycloneDX",
+    "description": "Generates CycloneDX Software Bill of Materials (SBOM) from .NET projects.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-dotnet",
+    "website_url": "https://www.nuget.org/packages/CycloneDX/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      ".NET"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_node_js.json
+++ b/tools/cyclonedx_for_node_js.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Node.js",
+    "publisher": "OWASP Foundation (CycloneDX Project)",
+    "description": "This is a so-called meta-package, it does not ship any own functionality, but it is a collection of optional dependencies with one purpose in common: generate CycloneDX Software-Bill-of-Materials (SBOM) from node-based projects.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-node-module",
+    "website_url": "https://www.npmjs.com/package/@cyclonedx/bom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "NODE.JS"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_npm.json
+++ b/tools/cyclonedx_for_npm.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for NPM",
+    "publisher": "CycloneDX",
+    "description": "Create CycloneDX Software Bill of Materials (SBOM) from npm projects.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-node-npm",
+    "website_url": "https://www.npmjs.com/package/@cyclonedx/cyclonedx-npm",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "NODE.JS"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_php_composer.json
+++ b/tools/cyclonedx_for_php_composer.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for PHP Composer",
+    "publisher": "CycloneDX",
+    "description": "Create CycloneDX Software Bill of Materials (SBOM) from PHP Composer projects.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-php-composer",
+    "website_url": "https://packagist.org/packages/cyclonedx/cyclonedx-php-composer",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMPOSER_PLUGIN",
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.1"
+    ],
+    "library": [
+      "PHP"
+    ],
+    "supportedLanguages": [
+      "PHP"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_python.json
+++ b/tools/cyclonedx_for_python.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Python",
+    "publisher": "CycloneDX",
+    "description": "Generates CycloneDX SBOMs from Python (virtual) environments, requirement files, and manifests (Poetry, PipEnv, etc)",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-python",
+    "website_url": "https://pypi.org/project/cyclonedx-bom/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.1",
+      "CYCLONEDX_V1.0"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_ruby_gems.json
+++ b/tools/cyclonedx_for_ruby_gems.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Ruby Gems",
+    "publisher": "OWASP Foundation",
+    "description": "Command-line utility and Ruby library that generates CycloneDX SBOMs for Ruby projects by analysing Gem dependencies.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-ruby-gem",
+    "website_url": "https://rubygems.org/gems/cyclonedx-ruby",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "RUBY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "RUBY"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_rust_cargo.json
+++ b/tools/cyclonedx_for_rust_cargo.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Rust Cargo",
+    "publisher": "CycloneDX Project (OWASP)",
+    "description": "Cargo sub-command and CLI library that generates CycloneDX SBOMs for Rust projects, aggregating all crate dependencies and outputting JSON or XML.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-rust-cargo",
+    "website_url": "https://crates.io/crates/cyclonedx-bom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "RUST"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "RUST"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_sbt_scala_.json
+++ b/tools/cyclonedx_for_sbt_scala_.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for SBT (Scala)",
+    "publisher": "Fabrizio Di Giuseppe",
+    "description": "SBT plugin that generates CycloneDX SBOMs (JSON or XML) for Scala/Java builds, supporting schema v1.6 and integrating smoothly with Dependency-Track.",
+    "repository_url": "https://github.com/sbt/sbt-sbom",
+    "website_url": "https://github.com/sbt/sbt-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "SCALA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "SCALA"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_webpack.json
+++ b/tools/cyclonedx_for_webpack.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Webpack",
+    "publisher": "OWASP Foundation",
+    "description": "Webpack plugin that generates CycloneDX Software Bill of Materials (SBOM) for JavaScript/TypeScript bundles during the build process.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin",
+    "website_url": "https://github.com/CycloneDX/cyclonedx-webpack-plugin",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "WEBPACK_PLUGIN"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "NODE.JS"
+    ]
+  }
+}

--- a/tools/cyclonedx_for_yarn.json
+++ b/tools/cyclonedx_for_yarn.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX for Yarn",
+    "publisher": "CycloneDX",
+    "description": "Create CycloneDX Software Bill of Materials (SBOM) from yarn projects.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-node-yarn",
+    "website_url": "https://classic.yarnpkg.com/en/package/@cyclonedx/yarn-plugin-cyclonedx",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "YARN_PLUGIN",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "NODE.JS"
+    ],
+    "supportedLanguages": [
+      "NODE.JS",
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/cyclonedx_gomod_generate_sbom.json
+++ b/tools/cyclonedx_gomod_generate_sbom.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX GoMod Generate SBOM",
+    "publisher": "CycloneDX",
+    "description": "GitHub action which generates CycloneDX SBOMs from Go modules, providing integration into CI/CD workflows for Go projects.",
+    "repository_url": "https://github.com/CycloneDX/gh-gomod-generate-sbom",
+    "website_url": "https://github.com/marketplace/actions/cyclonedx-gomod-generate-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/cyclonedx_javascript_library.json
+++ b/tools/cyclonedx_javascript_library.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX JavaScript Library",
+    "publisher": "CycloneDX",
+    "description": "Core functionality of CycloneDX for JavaScript (Node.js or Web Browser) written in TypeScript.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-javascript-library",
+    "website_url": "https://www.npmjs.com/package/@cyclonedx/cyclonedx-library",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "OBOM",
+      "MBOM",
+      "HBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "NODE.JS"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SWID"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS"
+    ]
+  }
+}

--- a/tools/cyclonedx_libraries_for_net.json
+++ b/tools/cyclonedx_libraries_for_net.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX Libraries for .NET",
+    "publisher": "CycloneDX",
+    "description": ".NET libraries to consume and produce CycloneDX Software Bill of Materials (SBOM).",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-dotnet-library",
+    "website_url": "https://www.nuget.org/profiles/CycloneDX",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "OBOM",
+      "MBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      ".NET"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SWID"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      ".NET"
+    ]
+  }
+}

--- a/tools/cyclonedx_library_for_go.json
+++ b/tools/cyclonedx_library_for_go.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX library for Go",
+    "publisher": "CycloneDX",
+    "description": "Go library that can parse, create and serialize CycloneDX Software Bill of Materials (SBOM) in JSON or XML.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-go",
+    "website_url": "https://github.com/CycloneDX/cyclonedx-go",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/cyclonedx_merge.json
+++ b/tools/cyclonedx_merge.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cyclonedx-merge",
+    "publisher": "fnxpt",
+    "description": "Tool to merge CycloneDX files (JSON/XML) with support for normal, flat, and smart merge modes.",
+    "repository_url": "https://github.com/fnxpt/cyclonedx-merge",
+    "website_url": "https://github.com/fnxpt/cyclonedx-merge",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/cyclonedx_net_generate_sbom.json
+++ b/tools/cyclonedx_net_generate_sbom.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX .NET Generate SBOM",
+    "publisher": "CycloneDX",
+    "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for .NET projects supporting multiple project formats and recursive analysis",
+    "repository_url": "https://github.com/CycloneDX/gh-dotnet-generate-sbom",
+    "website_url": "https://github.com/marketplace/actions/cyclonedx-dotnet-generate-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      ".NET"
+    ]
+  }
+}

--- a/tools/cyclonedx_node_js_generate_sbom.json
+++ b/tools/cyclonedx_node_js_generate_sbom.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX Node.js Generate SBOM",
+    "publisher": "CycloneDX",
+    "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for Node.js projects containing an aggregate of all project dependencies. (note: considered deprecated)",
+    "repository_url": "https://github.com/CycloneDX/gh-node-module-generatebom",
+    "website_url": "https://github.com/marketplace/actions/cyclonedx-node-js-generate-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "NODE.JS",
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/cyclonedx_npm_pipe.json
+++ b/tools/cyclonedx_npm_pipe.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cyclonedx-npm-pipe",
+    "publisher": "ShiftLeftCyber",
+    "description": "Bitbucket Pipe that packages cdxgen in a Docker image to generate CycloneDX v1.6 SBOMs for Node.js/npm projects in CI pipelines.",
+    "repository_url": "https://github.com/ccideas/cyclonedx-npm-pipe",
+    "website_url": "https://shiftleftcyber.io",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "SHELL"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "NODE.JS"
+    ]
+  }
+}

--- a/tools/cyclonedx_perl_library.json
+++ b/tools/cyclonedx_perl_library.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX Perl Library",
+    "publisher": "Giuseppe Di Terlizzi",
+    "description": "Perl library for generating CycloneDX SBOMs.",
+    "repository_url": "https://github.com/giterlizzi/perl-SBOM-CycloneDX",
+    "website_url": "https://github.com/giterlizzi/perl-SBOM-CycloneDX",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "PERL"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "PERL"
+    ]
+  }
+}

--- a/tools/cyclonedx_php_composer_generate_sbom.json
+++ b/tools/cyclonedx_php_composer_generate_sbom.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX PHP Composer Generate SBOM",
+    "publisher": "CycloneDX",
+    "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for PHP Composer projects (note: considered deprecated)",
+    "repository_url": "https://github.com/CycloneDX/gh-php-composer-generate-sbom",
+    "website_url": "https://github.com/marketplace/actions/cyclonedx-php-composer-generate-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "PHP"
+    ]
+  }
+}

--- a/tools/cyclonedx_php_library.json
+++ b/tools/cyclonedx_php_library.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX PHP Library",
+    "publisher": "CycloneDX",
+    "description": "PHP library that supplies data-models, serializers, validators and utilities for creating, parsing and validating CycloneDX BOM documents in JSON and XML formats.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-php-library",
+    "website_url": "https://packagist.org/packages/cyclonedx/cyclonedx-library",
+    "capabilities": [
+      "SBOM",
+      "HBOM",
+      "OBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "PHP"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.1"
+    ],
+    "supportedLanguages": [
+      "PHP"
+    ]
+  }
+}

--- a/tools/cyclonedx_python_generate_sbom.json
+++ b/tools/cyclonedx_python_generate_sbom.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX Python Generate SBOM",
+    "publisher": "CycloneDX",
+    "description": "GitHub Action to create a CycloneDX Software Bill-of-Materials (SBOM) for Python projects from requirements files (note: considered deprecated)",
+    "repository_url": "https://github.com/CycloneDX/gh-python-generate-sbom",
+    "website_url": "https://github.com/marketplace/actions/cyclonedx-python-generate-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/cyclonedx_python_library.json
+++ b/tools/cyclonedx_python_library.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX Python Library",
+    "publisher": "CycloneDX",
+    "description": "This Python package provides data models, validators and more, to help you create/render/read CycloneDX documents.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-python-lib",
+    "website_url": "https://pypi.org/project/cyclonedx-python-lib/",
+    "capabilities": [
+      "SBOM",
+      "CBOM",
+      "MBOM",
+      "OBOM",
+      "SAASBOM",
+      "RELEASE_NOTES",
+      "VDR/VEX",
+      "CDXA",
+      "HBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SWID"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.1",
+      "CYCLONEDX_V1.0"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/cyclonedx_rust.json
+++ b/tools/cyclonedx_rust.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX Rust",
+    "publisher": "Mark Dodgson",
+    "description": "Simple Rust library to encode and decode CycloneDX BOMs.",
+    "repository_url": "https://github.com/doddi/cyclonedx-rust",
+    "website_url": "https://github.com/doddi/cyclonedx-rust",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "RUST"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/cyclonedx_web_tool.json
+++ b/tools/cyclonedx_web_tool.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CycloneDX Web Tool",
+    "publisher": "CycloneDX",
+    "description": "Web-based tool for validating, viewing, and converting CycloneDX SBOMs. Supports XML/JSON, and conversion between CycloneDX and SPDX formats.",
+    "repository_url": "https://github.com/CycloneDX/cyclonedx-web-tool",
+    "website_url": "https://cyclonedx.github.io/cyclonedx-web-tool/",
+    "capabilities": [
+      "SBOM",
+      "OBOM",
+      "MBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.1",
+      "CYCLONEDX_V1.0"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/daggerboard.json
+++ b/tools/daggerboard.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "DaggerBoard",
+    "publisher": "NewYork-Presbyterian Hospital",
+    "description": "Vulnerability-scanning application that ingests CycloneDX or SPDX SBOM files, analyses listed dependencies for known CVEs, and presents results through a web dashboard.",
+    "repository_url": "https://github.com/nyph-infosec/daggerboard",
+    "website_url": "https://github.com/nyph-infosec/daggerboard",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON",
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/debricked.json
+++ b/tools/debricked.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Debricked",
+    "publisher": "OpenText",
+    "description": "Debricked lets teams automatically find, fix and prevent open-source vulnerabilities, avoid non-compliant licences and pick healthier dependencies, with CycloneDX SBOM import/export, CLI and SaaS dashboards.",
+    "repository_url": "https://github.com/debricked/cli",
+    "website_url": "https://debricked.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "PHP",
+      "PYTHON",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/defect_dojo.json
+++ b/tools/defect_dojo.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Defect Dojo",
+    "publisher": "OWASP",
+    "description": "Open source vulnerability management and automation platform that can import CycloneDX SBOMs and over 190 security tool reports for centralized vulnerability tracking and analysis.",
+    "repository_url": "https://github.com/DefectDojo/django-DefectDojo",
+    "website_url": "https://www.defectdojo.org/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/dependency_track.json
+++ b/tools/dependency_track.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Dependency-Track",
+    "publisher": "OWASP",
+    "description": "An intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain by leveraging SBOMs",
+    "repository_url": "https://github.com/DependencyTrack/dependency-track",
+    "website_url": "https://dependencytrack.org/",
+    "capabilities": [
+      "HBOM",
+      "OBOM",
+      "SAASBOM",
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "CONTAINER_IMAGE",
+      "APPLICATION"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "CPE",
+      "SWID"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "RUBY",
+      "PHP",
+      "RUST",
+      "C/C++",
+      ".NET",
+      "PERL",
+      "ERLANG_ELIXIR"
+    ]
+  }
+}

--- a/tools/dependency_track_jenkins_plugin.json
+++ b/tools/dependency_track_jenkins_plugin.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Dependency-Track Jenkins Plugin",
+    "publisher": "OWASP",
+    "description": "Jenkins plugin that publishes CycloneDX Software Bill-of-Materials (SBOM) to the Dependency-Track platform for vulnerability analysis and policy evaluation",
+    "repository_url": "https://github.com/jenkinsci/dependency-track-plugin",
+    "website_url": "https://plugins.jenkins.io/dependency-track/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "JENKINS_PLUGIN"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/dependency_track_maven_plugin.json
+++ b/tools/dependency_track_maven_plugin.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Dependency-Track Maven Plugin",
+    "publisher": "Paul McKeown",
+    "description": "Maven plugin that integrates with a Dependency-Track server to submit SBOMs and optionally fail execution when vulnerable dependencies are found",
+    "repository_url": "https://github.com/pmckeown/dependency-track-maven-plugin",
+    "website_url": "https://github.com/pmckeown/dependency-track-maven-plugin#readme",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "MAVEN_PLUGIN"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVA"
+    ]
+  }
+}

--- a/tools/distro2sbom.json
+++ b/tools/distro2sbom.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Distro2SBOM",
+    "publisher": "Anthony Harrison",
+    "description": "A command line tool which creates CycloneDX and SPDX SBOMs for an installed application or distribution (Debian, RPM, Windows and FreeBSD systems supported).",
+    "repository_url": "https://github.com/anthonyharrison/distro2sbom",
+    "website_url": "https://pypi.org/project/distro2sbom/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "transform": [
+      "BOM_STANDARD"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ]
+  }
+}

--- a/tools/docker_sbom_cli_plugin.json
+++ b/tools/docker_sbom_cli_plugin.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "docker-sbom-cli-plugin",
+    "publisher": "Docker",
+    "description": "Docker CLI plugin that generates Software Bills of Materials (SBOMs) for container images using Syft as the underlying scanner, with CycloneDX output support.",
+    "repository_url": "https://github.com/docker/sbom-cli-plugin",
+    "website_url": "https://github.com/docker/sbom-cli-plugin",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO",
+      "SHELL"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/dtrack_audit.json
+++ b/tools/dtrack_audit.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "dtrack-audit",
+    "publisher": "OZON",
+    "description": "Command-line client for OWASP Dependency-Track that publishes SBOMs and displays vulnerability information from the command line, designed for CI/CD integration",
+    "repository_url": "https://github.com/ozontech/dtrack-audit",
+    "website_url": "https://github.com/ozontech/dtrack-audit",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/dtrackauditor.json
+++ b/tools/dtrackauditor.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "DtrackAuditor",
+    "publisher": "Thinksabin",
+    "description": "Python CLI tool to upload CycloneDX SBOMs to Dependency-Track, analyze vulnerabilities, enforce policy, and fail CI builds based on thresholds.",
+    "repository_url": "https://github.com/thinksabin/DTrackAuditor",
+    "website_url": "https://github.com/thinksabin/DTrackAuditor",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/eclipse_sw360_antenna.json
+++ b/tools/eclipse_sw360_antenna.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Eclipse SW360 Antenna",
+    "publisher": "Eclipse Foundation",
+    "description": "Archived tool that scanned project artifacts, downloaded sources for dependencies, validated licenses, and generated license compliance documentation",
+    "repository_url": "https://github.com/eclipse-archived/antenna",
+    "website_url": "https://www.eclipse.org/sw360/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING",
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVA"
+    ]
+  }
+}

--- a/tools/emba.json
+++ b/tools/emba.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "EMBA",
+    "publisher": "EMBA Project",
+    "description": "EMBA is an open-source firmware security analyzer that extracts firmware, performs static and dynamic analysis, builds CycloneDX SBOMs with VEX data, and generates detailed vulnerability reports.",
+    "repository_url": "https://github.com/e-m-b-a/emba",
+    "website_url": "https://www.securefirmware.de",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "SHELL",
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/endor_labs.json
+++ b/tools/endor_labs.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Endor Labs",
+    "publisher": "Endor Labs",
+    "description": "Cloud-native platform that auto-creates CycloneDX SBOMs, generates VEX, and analyzes reachability so teams can securely select, integrate and maintain open-source software at scale.",
+    "website_url": "https://endorlabs.com",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "GITHUB_ACTION",
+      "GITLAB_CI_TEMPLATE"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/enso.json
+++ b/tools/enso.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Enso",
+    "publisher": "Enso Security",
+    "description": "Application Security Posture Management (ASPM) platform that inventories software assets, tracks AppSec tools and processes, and outputs CycloneDX and SPDX SBOMs with optional VEX ingest.",
+    "website_url": "https://www.enso.security",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/expliot_iot_security_assessment_framework.json
+++ b/tools/expliot_iot_security_assessment_framework.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "EXPLIoT IoT Security Assessment Framework",
+    "publisher": "EXPLIoT",
+    "description": "EXPLIoT is an AGPLv3 Python framework and CLI for assessing and exploiting IoT devices; it offers 140+ plug-ins and can generate CycloneDX SBOMs from firmware filesystems.",
+    "repository_url": "https://gitlab.com/expliot_framework/expliot",
+    "website_url": "https://expliot.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/fact.json
+++ b/tools/fact.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "FACT",
+    "publisher": "aDolus Technology Inc.",
+    "description": "The aDolus FACT platform is an advanced aggregation, analytics, and correlation engine that generates NTIA-compliant SBOMs (including CycloneDX) and provides continuous cybersecurity risk intelligence across the software supply chain.",
+    "website_url": "https://adolus.com",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "lifecycle": [
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "SWID"
+    ]
+  }
+}

--- a/tools/flawnter.json
+++ b/tools/flawnter.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Flawnter",
+    "publisher": "CyberTest",
+    "description": "Flawnter is a zero-trust static, dynamic and composition analysis platform that detects code flaws, vulnerabilities and license risks, and generates CycloneDX/SPDX SBOMs during every scan.",
+    "website_url": "https://www.flawnter.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "C/C++",
+      ".NET",
+      "JAVA",
+      "KOTLIN",
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "GO",
+      "RUBY",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/fortify_on_demand.json
+++ b/tools/fortify_on_demand.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Fortify on Demand",
+    "publisher": "Micro Focus",
+    "description": "SaaS application-security testing platform offering SAST, DAST and SCA. Produces and consumes CycloneDX SBOMs to secure the software supply chain across many languages, frameworks and package managers.",
+    "repository_url": "https://github.com/fortify/github-action",
+    "website_url": "https://www.microfocus.com/en-us/cyberres/application-security/fortify-on-demand",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "SCALA",
+      "KOTLIN",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/fortify_software_security_center.json
+++ b/tools/fortify_software_security_center.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Fortify Software Security Center",
+    "publisher": "Micro Focus",
+    "description": "Open-source CycloneDX parser plugin for Fortify SSC that imports SBOMs, correlates components with known vulnerabilities and licenses, and displays them in the SSC portal.",
+    "repository_url": "https://github.com/fortify/fortify-ssc-parser-generic-cyclonedx",
+    "website_url": "https://github.com/fortify/fortify-ssc-parser-generic-cyclonedx",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "CPE",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/fortress_asset_2_vendor.json
+++ b/tools/fortress_asset_2_vendor.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Fortress Asset 2 Vendor",
+    "publisher": "Fortress Information Security",
+    "description": "Comprehensive cyber supply chain risk management platform that ingests, analyzes and securely shares SBOMs, HBOMs and other supply chain attestations via SaaS and permissioned blockchain.",
+    "website_url": "https://assettovendor.com/",
+    "repository_url": "https://assettovendor.com",
+    "capabilities": [
+      "SBOM",
+      "HBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "DISTRIBUTE",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/fortress_file_integrity_assurance.json
+++ b/tools/fortress_file_integrity_assurance.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Fortress File Integrity Assurance",
+    "publisher": "Fortress Information Security",
+    "description": "A proprietary software analysis tool that validates patches and ensures software file integrity to enhance software supply chain security in critical infrastructure environments.",
+    "website_url": "https://www.fortressinfosec.com/",
+    "repository_url": "https://www.fortressinfosec.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/fossa.json
+++ b/tools/fossa.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "FOSSA",
+    "publisher": "FOSSA",
+    "description": "Subscription SCA platform and CLI that generate, import, analyse, and distribute CycloneDX or SPDX SBOMs for licence and vulnerability risk management across CI/CD pipelines.",
+    "repository_url": "https://github.com/fossas/fossa-cli",
+    "website_url": "https://fossa.com",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [
+      "BOM_STANDARD"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/gemnasium.json
+++ b/tools/gemnasium.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Gemnasium",
+    "publisher": "GitLab",
+    "description": "Dependency scanning analyzer that uses the GitLab Advisory Database to detect vulnerabilities in project dependencies and generates CycloneDX SBOMs.",
+    "repository_url": "https://gitlab.com/gitlab-org/security-products/analyzers/gemnasium",
+    "website_url": "https://docs.gitlab.com/ee/user/application_security/dependency_scanning/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE",
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "CONTAINER_IMAGE",
+      "GITLAB_CI_TEMPLATE"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "RUBY",
+      "PYTHON",
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS",
+      "JAVA",
+      "GO",
+      "PHP"
+    ]
+  }
+}

--- a/tools/generate_sbom_for_elixir_project.json
+++ b/tools/generate_sbom_for_elixir_project.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Generate SBoM for Elixir project",
+    "publisher": "Red Shirts",
+    "description": "GitHub Action to generate CycloneDX Software Bill-of-Materials (SBOM) for Erlang/Elixir Mix projects",
+    "repository_url": "https://github.com/red-shirts/action-mix-sbom",
+    "website_url": "https://github.com/marketplace/actions/generate-sbom-for-elixir-project",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [],
+    "transform": [],
+    "packaging": [
+      "GITHUB_ACTION",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "ERLANG_ELIXIR"
+    ]
+  }
+}

--- a/tools/gh_sbom.json
+++ b/tools/gh_sbom.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "gh-sbom",
+    "publisher": "GitHub",
+    "description": "CLI extension for the gh tool that generates CycloneDX or SPDX JSON SBOMs for any GitHub repository using Dependency Graph data.",
+    "repository_url": "https://github.com/advanced-security/gh-sbom",
+    "website_url": "https://github.com/advanced-security/gh-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/go_sonatypes.json
+++ b/tools/go_sonatypes.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Go Sonatypes",
+    "publisher": "Sonatype",
+    "description": "Common utility packages for working with OSS Index, Nexus IQ Server, CycloneDX SBOMs or getting a user-agent",
+    "repository_url": "https://github.com/sonatype-nexus-community/go-sona-types",
+    "website_url": "https://github.com/sonatype-nexus-community/go-sona-types",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/gobom.json
+++ b/tools/gobom.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "gobom",
+    "publisher": "Mattermost",
+    "description": "An extensible CycloneDX BOM generator and Dependency-Track API client written in Go; supports Go, npm, CocoaPods and Gradle projects and uploads SBOMs for analysis.",
+    "repository_url": "https://github.com/mattermost/gobom",
+    "website_url": "https://github.com/mattermost/gobom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVASCRIPT/TYPESCRIPT",
+      "JAVA",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/grype.json
+++ b/tools/grype.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Grype",
+    "publisher": "Anchore",
+    "description": "A vulnerability scanner for container images and filesystems. Works with Syft SBOMs and supports CycloneDX, SPDX, and OpenVEX.",
+    "repository_url": "https://github.com/anchore/grype",
+    "website_url": "https://github.com/anchore/grype",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL",
+      "CPE"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/heimdall.json
+++ b/tools/heimdall.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Heimdall",
+    "publisher": "MedCrypt",
+    "description": "Automatically extract or manually upload your Software Bill of Materials (SBOM), and Heimdall will, on a continual basis, identify known vulnerabilities affecting your software components",
+    "website_url": "https://www.medcrypt.com/solutions/helm",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/hermeto.json
+++ b/tools/hermeto.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Hermeto",
+    "publisher": "The Hermeto Project",
+    "description": "Hermeto is a CLI tool that pre-fetches your project's dependencies, which enables network-isolated builds, which enables the production of high-accuracy SBOMs",
+    "repository_url": "https://github.com/hermetoproject/hermeto",
+    "website_url": "https://hermetoproject.github.io/hermeto/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "SLSA",
+      "PACKAGE_URL"
+    ],
+    "supportedLanguages": [
+      "RUBY",
+      "RUST",
+      "GO",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/ion_channel_platform.json
+++ b/tools/ion_channel_platform.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Ion Channel Platform",
+    "publisher": "Ion Channel",
+    "description": "Risk management platform that enables analysis, exchange and continuous monitoring of Software Bills of Materials (SBOMs) to actively manage third party risk and compliance",
+    "website_url": "https://www.exiger.com/products/ion-channel/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/ittosai.json
+++ b/tools/ittosai.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ittosai",
+    "publisher": "DevOps KungFu Masters",
+    "description": "ittosai is a CycloneDX SBOM vulnerability analyzer that analyzes SBOMs every time a developer commits code to a repository.",
+    "repository_url": "https://github.com/devops-kung-fu/ittosai",
+    "website_url": "https://dkfm.io/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/jake.json
+++ b/tools/jake.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Jake",
+    "publisher": "Sonatype",
+    "description": "An OSS Index integration to check your Conda environments for vulnerable Open Source packages",
+    "repository_url": "https://github.com/sonatype-nexus-community/jake",
+    "website_url": "https://jake.readthedocs.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/jbom.json
+++ b/tools/jbom.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "jbom",
+    "publisher": "Eclipse Foundation (originally Contrast Security)",
+    "description": "jbom generates runtime and static CycloneDX SBOMs for local or remote Java applications and archives.",
+    "repository_url": "https://github.com/eclipse/jbom",
+    "website_url": "https://projects.eclipse.org/projects/technology.jbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "JAVA"
+    ]
+  }
+}

--- a/tools/jdisc_discovery.json
+++ b/tools/jdisc_discovery.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "JDisc Discovery",
+    "publisher": "JDisc",
+    "description": "Network discovery and IT inventory tool that can discover CycloneDX SBOMs on enterprise assets and ingest component inventory into the platform.",
+    "website_url": "https://www.jdisc.com/",
+    "repository_url": "https://www.jdisc.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/jetstack_secure.json
+++ b/tools/jetstack_secure.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Jetstack Secure",
+    "publisher": "Jetstack",
+    "description": "Manages machine identities across Cloud Native Kubernetes and OpenShift environments, providing a detailed view of enterprise security posture for TLS certificates and PKI.",
+    "repository_url": "https://github.com/jetstack/jetstack-secure",
+    "website_url": "https://www.jetstack.io/jetstack-secure/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "CONTAINER_IMAGE",
+      "APPLICATION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/jupiterone.json
+++ b/tools/jupiterone.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "JupiterOne",
+    "publisher": "JupiterOne",
+    "description": "Easily identify, map, analyze, and secure cyber assets and attack surface. Gain full visibility into complex cloud environments to uncover threats, close compliance gaps, and prioritize risk.",
+    "website_url": "https://jupiterone.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "WINDOWS",
+      "MAC",
+      "LINUX"
+    ],
+    "lifecycle": [
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/kbom_kubernetes_bill_of_materials_powered_by_ksoc.json
+++ b/tools/kbom_kubernetes_bill_of_materials_powered_by_ksoc.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "kbom - Kubernetes Bill of Materials powered by KSOC",
+    "publisher": "KSOC",
+    "description": "kbom is an open-source CLI tool from KSOC, written in Go, that generates detailed CycloneDX SBOMs for Kubernetes clusters, including nodes, control plane, OS, and cloud infrastructure details.",
+    "repository_url": "https://github.com/rad-security/kbom",
+    "website_url": "https://github.com/rad-security/kbom",
+    "capabilities": [
+      "SBOM",
+      "OBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/keysight_iot_security_assessment.json
+++ b/tools/keysight_iot_security_assessment.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Keysight IoT Security Assessment",
+    "publisher": "Keysight",
+    "description": "Automated firmware analysis platform that generates SBOMs and identifies vulnerabilities, misconfigurations, hardcoded credentials, weak cryptography, and potential zero-day vulnerabilities in IoT devices.",
+    "website_url": "https://www.keysight.com/be/en/products/network-security/iot-security-assessment.html",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/kics.json
+++ b/tools/kics.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "KICS",
+    "publisher": "Checkmarx",
+    "description": "KICS scans Infrastructure-as-Code to detect security vulnerabilities, compliance issues and misconfigurations, exporting results as CycloneDX SBOM and VDR reports.",
+    "repository_url": "https://github.com/Checkmarx/kics",
+    "website_url": "https://www.kics.io/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "AZURE_PIPELINE_EXTENSION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.3"
+    ]
+  }
+}

--- a/tools/ko.json
+++ b/tools/ko.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Ko",
+    "publisher": "Ko Build",
+    "description": "Simple, fast container image builder for Go applications that generates CycloneDX SBOMs by default, supports multi-platform builds, and integrates seamlessly with Kubernetes.",
+    "repository_url": "https://github.com/ko-build/ko",
+    "website_url": "https://ko.build/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/kondukto.json
+++ b/tools/kondukto.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Kondukto",
+    "publisher": "Kondukto",
+    "description": "Application Security Orchestration and Correlation platform that generates and consumes CycloneDX or SPDX SBOMs, correlates vulnerability scanner findings, and automates remediation workflows across CI/CD pipelines.",
+    "website_url": "https://kondukto.io",
+    "repository_url": "https://github.com/kondukto-io/kdt",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/kubeclarity.json
+++ b/tools/kubeclarity.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "KubeClarity",
+    "publisher": "Cisco",
+    "description": "Open-source platform (CLI, UI & Helm chart) that generates SBOMs, converts them between CycloneDX/SPDX formats, and scans container images, directories and running Kubernetes clusters for vulnerabilities, licences and CIS Docker benchmark findings.",
+    "repository_url": "https://github.com/openclarity/kubeclarity",
+    "website_url": "https://github.com/cisco-open/kubei",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "APPLICATION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/kyverno.json
+++ b/tools/kyverno.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Kyverno",
+    "publisher": "Kyverno Project (CNCF Incubating)",
+    "description": "Kyverno is an open-source Kubernetes policy engine that validates, mutates and generates configurations, and can evaluate CycloneDX SBOM attestations to enforce supply-chain policies.",
+    "repository_url": "https://github.com/kyverno/kyverno",
+    "website_url": "https://kyverno.io",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "POLICY_EVALUATION",
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/lagoon_insights_handler.json
+++ b/tools/lagoon_insights_handler.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Lagoon Insights Handler",
+    "publisher": "Lagoon",
+    "description": "Component that processes CycloneDX SBOMs and container image metadata for Lagoon environments, with vulnerability analysis via Trivy integration and customizable data filtering.",
+    "repository_url": "https://github.com/uselagoon/insights-handler",
+    "website_url": "https://lagoon.sh/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "CONTAINER_IMAGE",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/lib4sbom.json
+++ b/tools/lib4sbom.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Lib4sbom",
+    "publisher": "Anthony Harrison",
+    "description": "Python library that parses, converts and generates SBOMs in CycloneDX and SPDX formats, allowing JSON, Tag, YAML and XML serialization and programmatic manipulation of packages, files and dependencies.",
+    "repository_url": "https://github.com/anthonyharrison/lib4sbom",
+    "website_url": "https://pypi.org/project/lib4sbom/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/license_scanner.json
+++ b/tools/license_scanner.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "License Scanner",
+    "publisher": "CycloneDX",
+    "description": "license-scanner is an Apache-2.0 Go library and CLI that detects SPDX-style licenses and legal terms in source files and outputs CycloneDX v1.4 SBOMs with detailed license data.",
+    "repository_url": "https://github.com/CycloneDX/license-scanner",
+    "website_url": "https://github.com/CycloneDX/license-scanner",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/licensecompliancetool.json
+++ b/tools/licensecompliancetool.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "LicenseComplianceTool",
+    "publisher": "medavis GmbH",
+    "description": "Creates license manifests from CycloneDX SBOMs. Provides a Jenkins build step and CLI to list third-party components, their licenses, and download license texts to aid open-source compliance.",
+    "repository_url": "https://github.com/medavis-gmbh/LicenseComplianceTool",
+    "website_url": "https://github.com/medavis-gmbh/LicenseComplianceTool",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "JENKINS_PLUGIN",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "NODE.JS",
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/macaron.json
+++ b/tools/macaron.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "macaron",
+    "publisher": "Oracle",
+    "description": "Macaron is a supply chain security analysis tool and policy engine that checks conformance to frameworks such as SLSA, integrating CycloneDX SBOM generators or consuming existing SBOMs for automated analysis of build integrity and dependencies.",
+    "repository_url": "https://github.com/oracle/macaron",
+    "website_url": "https://oracle.github.io/macaron/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON",
+      "SHELL"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ]
+  }
+}

--- a/tools/manifest.json
+++ b/tools/manifest.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Manifest",
+    "publisher": "Manifest",
+    "description": "Manifest is a subscription SBOM management platform that auto-generates, aggregates, enriches, analyzes, and securely shares CycloneDX or SPDX SBOMs via web app and GitHub Action integration.",
+    "repository_url": "https://github.com/manifest-cyber/manifest-github-action",
+    "website_url": "https://manifestcyber.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/mdbom.json
+++ b/tools/mdbom.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "mdbom",
+    "publisher": "Robert Hansel",
+    "description": "A simple command line tool to transform CycloneDX SBoMs to markdown.",
+    "repository_url": "https://github.com/HaRo87/mdbom",
+    "website_url": "https://haro87.github.io/mdbom/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "PYTHON",
+      "JAVASCRIPT/TYPESCRIPT",
+      "GO"
+    ]
+  }
+}

--- a/tools/medscan.json
+++ b/tools/medscan.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "MedScan",
+    "publisher": "MedSec",
+    "description": "Consumes SBOMs to help hospitals manage medical device assets, providing vulnerability and resource analysis for compliance and risk management.",
+    "repository_url": "https://www.medsec.com/",
+    "website_url": "https://www.medsec.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "RESOURCE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/mend_sca.json
+++ b/tools/mend_sca.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Mend SCA",
+    "publisher": "Mend (Whitesource)",
+    "description": "Mend SCA provides software composition analysis that scans direct and transitive open-source dependencies, enforces security and license policies, and exports CycloneDX or SPDX SBOMs with optional VEX data.",
+    "repository_url": "https://github.com/mend-toolkit/Mend-SBOM-Export-CLI",
+    "website_url": "https://www.mend.io/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "JENKINS_PLUGIN",
+      "AZURE_PIPELINE_EXTENSION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "GO",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "RUBY",
+      "C/C++"
+    ]
+  }
+}

--- a/tools/meta_dependencytrack.json
+++ b/tools/meta_dependencytrack.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "meta-dependencytrack",
+    "publisher": "BG Networks",
+    "description": "meta-dependencytrack is a Yocto meta-layer which produces a CycloneDX Software Bill of Materials (aka SBOM) from your root filesystem and then uploads it to a Dependency-Track server against the project of your choice",
+    "repository_url": "https://github.com/bgnetworks/meta-dependencytrack",
+    "website_url": "https://github.com/bgnetworks/meta-dependencytrack",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON",
+      "SHELL"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}

--- a/tools/meta_package_manager.json
+++ b/tools/meta_package_manager.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Meta Package Manager",
+    "publisher": "Kevin Deldycke",
+    "description": "Export a SBOM of all packages installed on a Linux, macOS or Windows system.",
+    "repository_url": "https://github.com/kdeldycke/meta-package-manager",
+    "website_url": "https://kdeldycke.github.io/meta-package-manager/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      ".NET",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/meterian_boss_scanner.json
+++ b/tools/meterian_boss_scanner.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Meterian BOSS scanner",
+    "publisher": "Meterian",
+    "description": "Software composition analysis that inventories codebases and produces CycloneDX SBOMs while detecting security and licence risks across 12+ ecosystems.",
+    "repository_url": "https://github.com/MeterianHQ/meterian-github-action",
+    "website_url": "https://meterian.io/products/boss",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "SHELL"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "CPE"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/mlbomdoc.json
+++ b/tools/mlbomdoc.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "MLBOMdoc",
+    "publisher": "Anthony Harrison",
+    "description": "A command line tool which produces a human-readable representation of a CycloneDX ML Bill of Materials (MLBOM). Output formats include PDF and Markdown.",
+    "repository_url": "https://github.com/anthonyharrison/mlbomdoc",
+    "website_url": "https://pypi.org/project/mlbomdoc/",
+    "capabilities": [
+      "AI/ML-BOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/nancy.json
+++ b/tools/nancy.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Nancy",
+    "publisher": "Sonatype",
+    "description": "A tool to check for vulnerabilities in your Golang dependencies, powered by Sonatype OSS Index",
+    "repository_url": "https://github.com/sonatype-nexus-community/nancy",
+    "website_url": "https://github.com/sonatype-nexus-community/nancy",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/neo4cyclone.json
+++ b/tools/neo4cyclone.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Neo4Cyclone",
+    "publisher": "Javier Dominguez",
+    "description": "Neo4Cyclone is a tool that allows you to visualise your SBOMs using Neo4J.",
+    "repository_url": "https://github.com/javixeneize/neo4cyclone",
+    "website_url": "https://github.com/javixeneize/neo4cyclone",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/netrise_platform.json
+++ b/tools/netrise_platform.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "NetRise Platform",
+    "publisher": "NetRise",
+    "description": "The NetRise Platform generates SBOMs for binary code and post-build artifacts. It can ingest and analyze 3rd party SBOMs and provide guidance on risk mitigation, including CVEs, hardcoded credentials, cryptographic risk, and misconfigured services.",
+    "website_url": "https://www.netrise.io/",
+    "repository_url": "https://github.com/netriseinc",
+    "capabilities": [
+      "SBOM",
+      "CBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "RESOURCE_REPORTING",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_STANDARD"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "GITHUB_ACTION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "WINDOWS",
+      "MAC"
+    ],
+    "lifecycle": [
+      "DISCOVERY",
+      "OPERATIONS",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "CPE",
+      "PACKAGE_URL",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      ".NET",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/nexus_iq.json
+++ b/tools/nexus_iq.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Nexus IQ",
+    "publisher": "Sonatype",
+    "description": "Software Composition Analysis (SCA) platform that can consume, analyze, and produce CycloneDX SBOMs",
+    "website_url": "https://www.sonatype.com/product-nexus-lifecycle",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/nexus_lifecycle_jenkins_plugin.json
+++ b/tools/nexus_lifecycle_jenkins_plugin.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Nexus Lifecycle Jenkins Plugin",
+    "publisher": "Sonatype",
+    "description": "Publishes CycloneDX SBOMs to Nexus IQ for per-build analysis, result visualization, and policy evaluation",
+    "repository_url": "https://github.com/jenkinsci/nexus-platform-plugin",
+    "website_url": "https://help.sonatype.com/en/sonatype-platform-plugin-for-jenkins.html",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "JENKINS_PLUGIN"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/nim_lk.json
+++ b/tools/nim_lk.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "nim_lk",
+    "publisher": "Emery Hemingway",
+    "description": "Create and update SBOMs for the Nim programing language. Includes a translation module for the Nimble package manager as well as a Nix expression for building packages from SBOMs.",
+    "repository_url": "https://git.sr.ht/~ehmry/nim_lk",
+    "website_url": "https://git.sr.ht/~ehmry/nim_lk",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "NIM"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ]
+  }
+}

--- a/tools/noma.json
+++ b/tools/noma.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Noma",
+    "publisher": "Noma Security",
+    "description": "AI Application Security Platform for the entire AI lifecycle, focusing on AI asset discovery, ML-BOM, and AI supply chain risk management.",
+    "website_url": "https://noma.security",
+    "capabilities": [
+      "AI/ML-BOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "JAVA",
+      "C/C++",
+      ".NET",
+      "RUST",
+      "GO"
+    ]
+  }
+}

--- a/tools/nowsecure_platform.json
+++ b/tools/nowsecure_platform.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "NowSecure Platform",
+    "publisher": "NowSecure",
+    "description": "Mobile application security testing solution that automates static, dynamic and interactive testing, with SBOM capabilities through GitHub integrations",
+    "website_url": "https://www.nowsecure.com/products/nowsecure-platform/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "OUTDATED_COMPONENTS"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/ochrona_cli.json
+++ b/tools/ochrona_cli.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Ochrona CLI",
+    "publisher": "Ochrona",
+    "description": "A command line tool for detecting vulnerabilities in Python dependencies and doing safe package installs. Outputs CycloneDX SBOMs and supports policy enforcement.",
+    "repository_url": "https://github.com/ochronasec/ochrona-cli",
+    "website_url": "https://ochrona.dev/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/oligo_runtime_sbom.json
+++ b/tools/oligo_runtime_sbom.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Oligo Runtime SBOM",
+    "publisher": "Oligo",
+    "description": "Oligo Security delivers instant insights into actively executed libraries, assessing open source risks and confirming exploitability. It enables CycloneDX SBOM creation and auto-generates VEX.",
+    "website_url": "https://www.oligo.security/",
+    "repository_url": "https://www.oligo.security/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      ".NET",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/onekey_firmware_analysis_platform.json
+++ b/tools/onekey_firmware_analysis_platform.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ONEKEY firmware analysis platform",
+    "publisher": "ONEKEY",
+    "description": "Cloud-based platform that automatically extracts firmware images, enumerates components, and produces CycloneDX SBOM and vulnerability reports.",
+    "website_url": "https://onekey.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "OUTDATED_COMPONENTS",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}

--- a/tools/openrewrite.json
+++ b/tools/openrewrite.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "OpenRewrite",
+    "publisher": "OpenRewrite Project",
+    "description": "Open-source automated refactoring ecosystem for code transformation, security remediation, and dependency management through reusable recipes and build tool plugins.",
+    "repository_url": "https://github.com/openrewrite/rewrite",
+    "website_url": "https://docs.openrewrite.org/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "RESOURCE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "LIBRARY",
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY",
+      "MAVEN_PLUGIN"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVA",
+      "KOTLIN",
+      "GROOVY",
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/oss_inventory.json
+++ b/tools/oss_inventory.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "OSS Inventory",
+    "publisher": "Thiago Pinto",
+    "description": "A web application for importing, storing, and visualizing CycloneDX SBOMs, allowing organizations to track software components across projects.",
+    "repository_url": "https://github.com/thspinto/oss_inventory",
+    "website_url": "https://github.com/thspinto/oss_inventory",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "RESOURCE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/oss_review_toolkit_ort_.json
+++ b/tools/oss_review_toolkit_ort_.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "OSS Review Toolkit (ORT)",
+    "publisher": "OSS Review Toolkit",
+    "description": "A comprehensive suite of tools to automate software compliance checks, analyze dependencies / vulnerabilities, and generate reports.",
+    "repository_url": "https://github.com/oss-review-toolkit/ort",
+    "website_url": "https://oss-review-toolkit.org/",
+    "capabilities": [
+      "SBOM",
+      "CBOM",
+      "OBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "LIBRARY",
+      "APPLICATION",
+      "GITHUB_ACTION",
+      "GITLAB_CI_TEMPLATE",
+      "JENKINS_PLUGIN"
+    ],
+    "library": [
+      "JAVA",
+      "KOTLIN"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "CPE",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.1",
+      "CYCLONEDX_V1.0"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      ".NET",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "KOTLIN",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SCALA",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/osv.json
+++ b/tools/osv.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "OSV",
+    "publisher": "Google",
+    "description": "Open source vulnerability database and scanner that accepts CycloneDX SBOMs as input and identifies known vulnerabilities in components across multiple ecosystems.",
+    "repository_url": "https://github.com/google/osv.dev",
+    "website_url": "https://osv.dev/",
+    "capabilities": [
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "PYTHON",
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      ".NET"
+    ]
+  }
+}

--- a/tools/parlay.json
+++ b/tools/parlay.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Parlay",
+    "publisher": "Snyk",
+    "description": "Parlay is an Apache-licensed CLI written in Go that takes CycloneDX 1.4 JSON/XML or SPDX 2.3 SBOMs and enriches them with licence, vulnerability, maintainer and scorecard data from services like ecosyste.ms, Snyk and OpenSSF.",
+    "repository_url": "https://github.com/snyk/parlay",
+    "website_url": "https://github.com/snyk/parlay",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/pip_audit.json
+++ b/tools/pip_audit.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "pip-audit",
+    "publisher": "Trail of Bits",
+    "description": "Audits Python environments and dependency trees for known vulnerabilities and can emit CycloneDX SBOMs of affected components.",
+    "repository_url": "https://github.com/pypa/pip-audit",
+    "website_url": "https://github.com/pypa/pip-audit",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/prisma_cloud.json
+++ b/tools/prisma_cloud.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Prisma Cloud",
+    "publisher": "Palo Alto Networks",
+    "description": "Unified cloud-native application protection platform that scans code, pipelines, infrastructure and runtime to generate CycloneDX SBOMs, analyze vulnerabilities, licenses and misconfigurations, and secure entitlements across multi-cloud environments.",
+    "website_url": "https://www.paloaltonetworks.com/prisma/cloud",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "JENKINS_PLUGIN"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/procap360.json
+++ b/tools/procap360.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ProCap360",
+    "publisher": "Internet Infrastructure Services Corp.",
+    "description": "An advanced SBOM, RBOM and AIBOM  cybersecurity risk management tool using novel knowledge graph technology to enhance software supply chain security and visually display real time application assurance.",
+    "repository_url": "https://github.com/ProCap360",
+    "website_url": "https://procap360.com",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "CBOM",
+      "HBOM",
+      "OBOM",
+      "AI/ML-BOM",
+      "VDR/VEX",
+      "CDXA",
+      "RELEASE_NOTES"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "SIGNING/NOTARY",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING",
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "AZURE_PIPELINE_EXTENSION"
+    ],
+    "library": [
+      "GO",
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "C/C++"
+    ]
+  }
+}

--- a/tools/product_security_hub_psh_.json
+++ b/tools/product_security_hub_psh_.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Product Security Hub (PSH)",
+    "publisher": "Product Security Hub, LLC",
+    "description": "Cloud-based tool to import, export, view, create, edit, and transform CycloneDX SBOMs and human-readable SBOMs, as well as manage VEX data.",
+    "website_url": "https://www.ProductSecurityHub.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/project_piper.json
+++ b/tools/project_piper.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Project Piper",
+    "publisher": "SAP",
+    "description": "Project Piper is an open-source Jenkins shared library and CLI that automates SAP-centric CI/CD pipelines and can generate CycloneDX SBOMs for Maven, Python, Go, container, and other builds.",
+    "repository_url": "https://github.com/SAP/jenkins-library",
+    "website_url": "https://www.project-piper.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [],
+    "transform": [],
+    "packaging": [
+      "LIBRARY",
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "PYTHON",
+      "GO",
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/pulseuno_plugin_for_dimensions_cm.json
+++ b/tools/pulseuno_plugin_for_dimensions_cm.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "PulseUno Plugin for Dimensions CM",
+    "publisher": "Micro Focus",
+    "description": "PulseUno enables development teams to continually build and inspect the health and quality of code using plugins such as CycloneDX. Teams can use this information for merge, deployment, and release decisions.",
+    "repository_url": "https://www.microfocus.com/en-us/products/dimensions-cm",
+    "website_url": "https://www.microfocus.com/en-us/products/dimensions-cm",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "PACKAGE_MANAGER_INTEGRATION",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/rapidfort.json
+++ b/tools/rapidfort.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "RapidFort",
+    "publisher": "RapidFort",
+    "description": "Container-optimization platform that scans, profiles and hardens images, generates SBOMs, converts to CycloneDX/SPDX, and exports VEX to prioritize exploitable CVEs.",
+    "website_url": "https://www.rapidfort.com/",
+    "repository_url": "https://github.com/rapidfort/community-images",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "TRANSFORM",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/rearm.json
+++ b/tools/rearm.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ReARM",
+    "publisher": "Reliza",
+    "description": "ReARM is a system to store, organize and manage SBOMs / xBOMs with Component and Product releases.",
+    "repository_url": "https://github.com/relizaio/rearm",
+    "website_url": "https://rearmhq.com",
+    "capabilities": [
+      "AI/ML-BOM",
+      "CBOM",
+      "CDXA",
+      "OBOM",
+      "RELEASE_NOTES",
+      "SAASBOM",
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DECOMMISSION"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      ".NET",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "GO",
+      "NODE.JS"
+    ]
+  }
+}

--- a/tools/rebom.json
+++ b/tools/rebom.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Rebom",
+    "publisher": "Reliza",
+    "description": "Open source catalog for storing, managing, and distributing CycloneDX Software Bills of Materials (SBOMs) in JSON format, with features for validation, merging, and analysis.",
+    "repository_url": "https://github.com/relizaio/rebom",
+    "website_url": "https://rebomdemo.relizahub.com",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "DISTRIBUTE",
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING",
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [
+      "BOM_VERSION",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "CONTAINER_IMAGE",
+      "APPLICATION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/reliza_hub.json
+++ b/tools/reliza_hub.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Reliza Hub",
+    "publisher": "Reliza",
+    "description": "Publishes and ingests SBOMs for metadata management, compliance, and distribution. Supports CycloneDX and SPDX standards for software supply chain transparency.",
+    "repository_url": "https://relizahub.com/",
+    "website_url": "https://relizahub.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "DISTRIBUTE",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "RESOURCE_REPORTING",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "WINDOWS",
+      "MAC"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/retire_js.json
+++ b/tools/retire_js.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Retire.js",
+    "publisher": "RetireJS",
+    "description": "Scanner that detects the use of JavaScript libraries with known vulnerabilities in web and Node.js applications and can generate CycloneDX-format SBOMs.",
+    "repository_url": "https://github.com/RetireJS/retire.js",
+    "website_url": "https://retirejs.github.io/retire.js",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "NODE.JS"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS"
+    ]
+  }
+}

--- a/tools/rezilion_dynamic_sbom.json
+++ b/tools/rezilion_dynamic_sbom.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Rezilion Dynamic SBOM",
+    "publisher": "Rezilion",
+    "description": "Continuous, runtime-aware SBOM platform that inventories every file, package and dependency across Windows and Linux hosts, containers and CI/CD pipelines, exports CycloneDX/VEX and validates vulnerability exploitability in real time.",
+    "website_url": "https://www.rezilion.com/platform/dynamic-sbom",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "JENKINS_PLUGIN",
+      "GITLAB_CI_TEMPLATE"
+    ],
+    "platform": [
+      "LINUX",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PYTHON",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/rkvst_sbom_hub.json
+++ b/tools/rkvst_sbom_hub.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "RKVST SBOM Hub",
+    "publisher": "RKVST",
+    "description": "Free SaaS repository to discover, store and permission-share CycloneDX v1.4 SBOMs with immutable provenance, VEX support and continuous assurance.",
+    "repository_url": "https://github.com/jitsuin-inc/archivist-samples",
+    "website_url": "https://www.datatrails.ai/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "FREEMIUM"
+    ],
+    "functions": [
+      "DISTRIBUTE",
+      "SIGNING/NOTARY"
+    ],
+    "analysis": [],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SWID"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/rollup_plugin_sbom.json
+++ b/tools/rollup_plugin_sbom.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Rollup Plugin SBOM",
+    "publisher": "Jan Biasi",
+    "description": "Creates CycloneDX SBOMs for frontend Javascript apps bundled with rollup or vite.",
+    "repository_url": "https://github.com/janbiasi/rollup-plugin-sbom",
+    "website_url": "https://www.npmjs.com/package/rollup-plugin-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "packaging": [
+      "ROLLUP_PLUGIN"
+    ]
+  }
+}

--- a/tools/runsafe_c_c_build_time_sbom_generator.json
+++ b/tools/runsafe_c_c_build_time_sbom_generator.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "RunSafe C/C++ Build-time SBOM Generator",
+    "publisher": "RunSafe Security",
+    "description": "Generates a C/C++ SBOM at build-time without a package manager, working across build environments and reporting on all library dependencies.",
+    "website_url": "https://runsafesecurity.com/c-c-plus-plus-sbom/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "C/C++"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "C/C++"
+    ]
+  }
+}

--- a/tools/salus.json
+++ b/tools/salus.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Salus",
+    "publisher": "Coinbase",
+    "description": "Salus is a tool for coordinating the execution of security scanners. Salus can generate CycloneDX SBOMs from many language ecosystems.",
+    "repository_url": "https://github.com/coinbase/salus",
+    "website_url": "https://github.com/coinbase/salus",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "supportedLanguages": [
+      "RUBY",
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS",
+      "PYTHON",
+      "GO",
+      "RUST"
+    ]
+  }
+}

--- a/tools/sbom2doc.json
+++ b/tools/sbom2doc.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM2doc",
+    "publisher": "Anthony Harrison",
+    "description": "SBOM2doc converts CycloneDX or SPDX SBOMs into human-readable reports in PDF, Markdown, HTML, Excel or console formats via a cross-platform Python CLI.",
+    "repository_url": "https://github.com/anthonyharrison/sbom2doc",
+    "website_url": "https://pypi.org/project/sbom2doc/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/sbom2dot.json
+++ b/tools/sbom2dot.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM2dot",
+    "publisher": "Anthony Harrison",
+    "description": "CLI that reads CycloneDX or SPDX SBOMs and emits a GraphViz-compatible DOT file so you can visualise component and dependency relationships.",
+    "repository_url": "https://github.com/anthonyharrison/sbom2dot",
+    "website_url": "https://pypi.org/project/sbom2dot/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM",
+      "ANALYSIS"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/sbom4files.json
+++ b/tools/sbom4files.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM4Files",
+    "publisher": "Anthony Harrison",
+    "description": "Command-line tool that scans a directory and generates CycloneDX (JSON) or SPDX SBOMs for its files.",
+    "repository_url": "https://github.com/anthonyharrison/sbom4files",
+    "website_url": "https://pypi.org/project/sbom4files/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/sbom4python.json
+++ b/tools/sbom4python.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM4Python",
+    "publisher": "Anthony Harrison",
+    "description": "CLI utility that produces CycloneDX or SPDX SBOMs for installed Python modules or requirements files, identifying dependencies and their licenses, with optional dependency graph output.",
+    "repository_url": "https://github.com/anthonyharrison/sbom4python",
+    "website_url": "https://pypi.org/project/sbom4python/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/sbom4rust.json
+++ b/tools/sbom4rust.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM4Rust",
+    "publisher": "Anthony Harrison",
+    "description": "CLI that reads Cargo.lock and authors CycloneDX v1.6 or SPDX SBOMs for Rust projects.",
+    "repository_url": "https://github.com/anthonyharrison/sbom4rust",
+    "website_url": "https://github.com/anthonyharrison/sbom4rust",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "RUST"
+    ]
+  }
+}

--- a/tools/sbom_action.json
+++ b/tools/sbom_action.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "sbom-action",
+    "publisher": "Pete Wagner",
+    "description": "GitHub Action that fetches and diffs CycloneDX SBOMs for container images, posting comments or opening pull requests when package or vulnerability changes are detected.",
+    "repository_url": "https://github.com/thepwagner/sbom-action",
+    "website_url": "https://github.com/thepwagner/sbom-action",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/sbom_assembler.json
+++ b/tools/sbom_assembler.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Assembler",
+    "publisher": "Interlynk.io",
+    "description": "sbomasm is a command-line tool that assembles product SBOMs from component SBOMs, supporting CycloneDX and SPDX formats for streamlined management and distribution.",
+    "repository_url": "https://github.com/interlynk-io/sbomasm",
+    "website_url": "https://www.interlynk.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/sbom_benchmark.json
+++ b/tools/sbom_benchmark.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Benchmark",
+    "publisher": "Interlynk.io",
+    "description": "SBOM Benchmark is an Apache-licensed web application that scores CycloneDX 1.4/1.5 and SPDX SBOMs for quality and compliance, generating shareable reports via the sbomqs engine.",
+    "repository_url": "https://github.com/interlynk-io/sbombenchmark.dev",
+    "website_url": "https://sbombenchmark.dev/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED",
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/sbom_cli.json
+++ b/tools/sbom_cli.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM CLI",
+    "publisher": "Defense Unicorns",
+    "description": "Creates CycloneDX SBOMs from Kubernetes Helm charts",
+    "capabilities": [],
+    "availability": [],
+    "functions": [],
+    "packaging": [],
+    "platform": [],
+    "lifecycle": [],
+    "supportedStandards": [],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/sbom_explorer.json
+++ b/tools/sbom_explorer.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Explorer",
+    "publisher": "Interlynk.io",
+    "description": "sbomex is a command line utility to help query and pull from Interlynk's public SBOM repository.",
+    "repository_url": "https://github.com/interlynk-io/sbomex",
+    "website_url": "https://www.interlynk.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/sbom_grep.json
+++ b/tools/sbom_grep.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Grep",
+    "publisher": "Interlynk.io",
+    "description": "Command-line utility (`sbomgr`) that performs grep-style searches across SBOMs by name, checksum, CPE, and PURL.",
+    "repository_url": "https://github.com/interlynk-io/sbomgr",
+    "website_url": "https://www.interlynk.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}

--- a/tools/sbom_insights.json
+++ b/tools/sbom_insights.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Insights",
+    "publisher": "Revenera",
+    "description": "SBOM Insights is a subscription-based SaaS platform that ingests SBOMs in CycloneDX and SPDX formats, reconciles and analyzes components for vulnerabilities, license compliance and outdated parts, and generates reports and compliance artifacts.",
+    "website_url": "https://www.revenera.com/software-composition-analysis/products/sbom-insights",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "TRANSFORM",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/sbom_manager.json
+++ b/tools/sbom_manager.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM-Manager",
+    "publisher": "Anthony Harrison",
+    "description": "SBOM-Manager is an open-source Python CLI that stores, queries, and scans CycloneDX 1.4/1.5 and SPDX 2.3 SBOMs via a local repository to support audit and vulnerability investigations.",
+    "repository_url": "https://github.com/anthonyharrison/sbom-manager",
+    "website_url": "https://pypi.org/project/sbom-manager/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/sbom_observer.json
+++ b/tools/sbom_observer.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Observer",
+    "publisher": "Bytesafe",
+    "description": "SBOM Observer provides a comprehensive SBOM workflow to help you manage your software supply chain. Leverage the powerful combination of the Policy Engine and Operational Model to guarantee the security and compliance of your software.",
+    "website_url": "https://sbom.observer/",
+    "repository_url": "https://github.com/marketplace/actions/sbom-observer-scan-and-upload",
+    "capabilities": [
+      "SBOM",
+      "RELEASE_NOTES",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION",
+      "CONTAINER_IMAGE"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "SLSA"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT",
+      "ERLANG_ELIXIR",
+      "SCALA",
+      "KOTLIN",
+      "GROOVY",
+      "FORTRAN"
+    ]
+  }
+}

--- a/tools/sbom_operator.json
+++ b/tools/sbom_operator.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM-Operator",
+    "publisher": "Christian Kotzbauer",
+    "description": "Catalogue all container images running in a Kubernetes cluster and publish Software Bill of Materials (SBOM) documents, generated with Syft, to multiple back-ends.",
+    "repository_url": "https://github.com/ckotzbauer/sbom-operator",
+    "website_url": "https://github.com/ckotzbauer/sbom-operator",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [],
+    "transform": [],
+    "packaging": [
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/sbom_quality_score.json
+++ b/tools/sbom_quality_score.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Quality Score",
+    "publisher": "Interlynk.io",
+    "description": "Command-line utility that evaluates the quality and compliance of CycloneDX and SPDX SBOMs across multiple categories, enabling automated policy gates in CI/CD workflows.",
+    "repository_url": "https://github.com/interlynk-io/sbomqs",
+    "website_url": "https://www.interlynk.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/sbom_rs.json
+++ b/tools/sbom_rs.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "sbom-rs",
+    "publisher": "Paul Sastrasinh",
+    "description": "A group of Rust projects for interacting with and producing software bill of materials (SBOMs).",
+    "repository_url": "https://github.com/psastras/sbom-rs",
+    "website_url": "https://github.com/psastras/sbom-rs",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "RUST"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "RUST"
+    ]
+  }
+}

--- a/tools/sbom_scorecard.json
+++ b/tools/sbom_scorecard.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Scorecard",
+    "publisher": "eBay",
+    "description": "SBOM Scorecard evaluates SBOMs for specification compliance, generation metadata, and package details, supporting CycloneDX, SPDX, and Syft formats.",
+    "repository_url": "https://github.com/eBay/sbom-scorecard",
+    "website_url": "https://github.com/eBay/sbom-scorecard",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "library": [
+      "GO"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/sbom_sh.json
+++ b/tools/sbom_sh.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM.sh",
+    "publisher": "Codenotary Inc",
+    "description": "SBOM.sh is a free service to store, visualize and globally share CycloneDX SBOM files by simply using HTTP requests or curl.",
+    "repository_url": "https://github.com/codenotary/sbom.sh-container",
+    "website_url": "https://sbom.sh",
+    "capabilities": [
+      "SBOM",
+      "RELEASE_NOTES"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "FREEMIUM"
+    ],
+    "functions": [
+      "DISTRIBUTE",
+      "AUTHOR",
+      "SIGNING/NOTARY"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "SHELL"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/sbom_submission_action.json
+++ b/tools/sbom_submission_action.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "sbom-submission-action",
+    "publisher": "TietoEVRY",
+    "description": "GitHub Action that uploads CycloneDX SBOM files to GitHub\u2019s dependency submission API, enabling Dependabot security analysis downstream.",
+    "repository_url": "https://github.com/evryfs/sbom-dependency-submission-action",
+    "website_url": "https://github.com/marketplace/actions/sbom-submission-action",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "analysis": [],
+    "transform": [],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/sbom_swissarmy_bitbucket_pipe.json
+++ b/tools/sbom_swissarmy_bitbucket_pipe.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "sbom-swissarmy-bitbucket-pipe",
+    "publisher": "ShiftLeftCyber",
+    "description": "A Bitbucket Pipe containing a collection of open source tools to perform additional analysis on a CycloneDX or SPDX SBOM.",
+    "repository_url": "https://github.com/shiftleftcyber/sbom-utilities-pipe",
+    "website_url": "https://shiftleftcyber.io",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "CBOM",
+      "AI/ML-BOM",
+      "HBOM",
+      "MBOM",
+      "OBOM",
+      "RELEASE_NOTES",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM",
+      "SIGNING/NOTARY"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY",
+      "DECOMMISSION"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL",
+      "CPE",
+      "OMNIBOR",
+      "SWID"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT",
+      "ERLANG_ELIXIR",
+      "SCALA",
+      "KOTLIN",
+      "GROOVY",
+      "FORTRAN"
+    ]
+  }
+}

--- a/tools/sbom_utility_sbom_utility_.json
+++ b/tools/sbom_utility_sbom_utility_.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Utility (sbom-utility)",
+    "publisher": "CycloneDX",
+    "description": "Go-based CLI and API to validate, query, trim and patch CycloneDX or SPDX BOMs, report on components, licences and vulnerabilities, and handle all CycloneDX variants up to v1.6.",
+    "repository_url": "https://github.com/CycloneDX/sbom-utility",
+    "website_url": "https://github.com/CycloneDX/sbom-utility",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ]
+  }
+}

--- a/tools/sbom_validator.json
+++ b/tools/sbom_validator.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "sbom-validator",
+    "publisher": "ShiftLeftCyber",
+    "description": "A lightweight Go library for validating Software Bill of Materials (SBOM) against industry-standard specifications.",
+    "repository_url": "https://github.com/shiftleftcyber/sbom-validator",
+    "website_url": "https://shiftleftcyber.io",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "GO"
+    ]
+  }
+}

--- a/tools/sbom_vendor_management.json
+++ b/tools/sbom_vendor_management.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Vendor Management",
+    "publisher": "SettleTop, Inc.",
+    "description": "Manage, assess, store and monitor all your vendor\u2019s SBOMs in one secure, centralized dashboard to improve supply chain security.",
+    "website_url": "https://www.settletop.com/sbom",
+    "repository_url": "https://www.settletop.com/sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ]
+  }
+}

--- a/tools/sbomaudit.json
+++ b/tools/sbomaudit.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOMAudit",
+    "publisher": "Anthony Harrison",
+    "description": "SBOMAudit is a command-line utility that audits CycloneDX or SPDX SBOMs against NTIA minimum requirements, license policies, allow/deny lists, and package age to flag outdated or non-compliant components.",
+    "repository_url": "https://github.com/anthonyharrison/sbomaudit",
+    "website_url": "https://pypi.org/project/sbomaudit/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "CPE",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "PERL",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/sbomcenter.json
+++ b/tools/sbomcenter.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOMcenter",
+    "publisher": "Codenotary Inc",
+    "description": "SBOMcenter.io is a free service to get insights into the ingredients of your software for free and without any software.",
+    "website_url": "https://sbomcenter.io",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION",
+      "CONTAINER_IMAGE"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "PYTHON",
+      "JAVASCRIPT/TYPESCRIPT",
+      "GO",
+      "RUST"
+    ]
+  }
+}

--- a/tools/sbomdiff.json
+++ b/tools/sbomdiff.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOMDiff",
+    "publisher": "Anthony Harrison",
+    "description": "SBOMDiff is an Apache-2.0 CLI that compares two SBOM files (CycloneDX 1.4 or SPDX 2.3), highlighting package additions, removals, version or license changes, and outputs text, JSON or YAML reports.",
+    "repository_url": "https://github.com/anthonyharrison/sbomdiff",
+    "website_url": "https://pypi.org/project/sbomdiff/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/sbomify.json
+++ b/tools/sbomify.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "sbomify",
+    "publisher": "sbomify",
+    "description": "sbomify is a comprehensive SBOM management platform that enables secure sharing and analysis of Software Bill of Materials. Seamlessly integrates with CI/CD pipelines.",
+    "website_url": "https://sbomify.com",
+    "repository_url": "https://github.com/sbomify/sbomify",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE",
+      "TRANSFORM"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/sbommerge.json
+++ b/tools/sbommerge.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOMMerge",
+    "publisher": "Anthony Harrison",
+    "description": "Command-line utility that merges two SBOM files, supporting CycloneDX and SPDX inputs and outputs in tag, JSON or YAML formats.",
+    "repository_url": "https://github.com/anthonyharrison/sbommerge",
+    "website_url": "https://pypi.org/project/sbommerge/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/sbomtrend.json
+++ b/tools/sbomtrend.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOMTrend",
+    "publisher": "Anthony Harrison",
+    "description": "A command line tool which analyses a set of SBOMs to identify license and version changes in components.",
+    "repository_url": "https://github.com/anthonyharrison/sbomtrend",
+    "website_url": "https://pypi.org/project/sbomtrend/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_STANDARD"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/sca_codeinsight_reports_cyclonedx.json
+++ b/tools/sca_codeinsight_reports_cyclonedx.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "sca-codeinsight-reports-cyclonedx",
+    "publisher": "Flexera",
+    "description": "Generates CycloneDX SBOM reports (XML and JSON) for projects scanned in Flexera Code Insight.",
+    "repository_url": "https://github.com/flexera-public/sca-codeinsight-reports-cyclonedx",
+    "website_url": "https://github.com/flexera-public/sca-codeinsight-reports-cyclonedx",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}

--- a/tools/scancode_toolkit.json
+++ b/tools/scancode_toolkit.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Scancode Toolkit",
+    "publisher": "nexB",
+    "description": "Detects licenses, copyrights, package manifests & dependencies by scanning code to discover and inventory open source and third-party packages",
+    "repository_url": "https://github.com/nexB/scancode-toolkit",
+    "website_url": "https://github.com/nexB/scancode-toolkit",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/scanoss.json
+++ b/tools/scanoss.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SCANOSS",
+    "publisher": "SCANOSS",
+    "description": "Open source software identification and inventory tool that provides insights into license compliance, security vulnerabilities, and software composition analysis",
+    "repository_url": "https://github.com/scanoss/engine",
+    "website_url": "https://www.scanoss.com/",
+    "capabilities": [],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/secobserve.json
+++ b/tools/secobserve.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SecObserve",
+    "publisher": "MaibornWolff",
+    "description": "Open-source platform that aggregates findings and CycloneDX SBOMs from many scanners, lets teams assess security and license risks, and reports results via dashboards and APIs.",
+    "repository_url": "https://github.com/MaibornWolff/SecObserve",
+    "website_url": "https://maibornwolff.github.io/SecObserve",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON",
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "KOTLIN"
+    ]
+  }
+}

--- a/tools/securestack.json
+++ b/tools/securestack.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SecureStack",
+    "publisher": "SecureStack",
+    "description": "SecureStack analyzes your application and finds all source code, cloud stack and third-party services and builds a CycloneDX SBOM every time you deploy",
+    "repository_url": "https://github.com/SecureStackCo/actions-sbom",
+    "website_url": "https://securestack.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "DISTRIBUTE",
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/semgrep.json
+++ b/tools/semgrep.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Semgrep",
+    "publisher": "Semgrep Inc",
+    "description": "Semgrep is an application security platform where developers can scan for vulnerabilities in code (SAST), in OSS dependencies (SCA), and secrets. Semgrep creates CycloneDX SBOMs that enrich vulnerabilities with reachability analysis.",
+    "website_url": "https://semgrep.dev",
+    "repository_url": "https://github.com/semgrep/semgrep",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "FREEMIUM",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON",
+      "OCAML"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SCALA",
+      "SWIFT",
+      "KOTLIN",
+      "GROOVY",
+      "FORTRAN"
+    ]
+  }
+}

--- a/tools/shiftleft_scan.json
+++ b/tools/shiftleft_scan.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ShiftLeft Scan",
+    "publisher": "ShiftLeft",
+    "description": "A free open-source security tool for modern DevOps teams that performs static analysis-based security testing across multiple languages and frameworks",
+    "repository_url": "https://github.com/ShiftLeftSecurity/sast-scan",
+    "website_url": "https://www.shiftleft.io/scan/",
+    "capabilities": [],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "PACKAGE_URL"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/snykvulncheck.json
+++ b/tools/snykvulncheck.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SnykVulnCheck",
+    "publisher": "Andrii Grytsenko",
+    "description": "Command-line tool that analyzes CycloneDX SBOMs and evaluates components for known vulnerabilities by querying the public Snyk Vulnerability Database API.",
+    "repository_url": "https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck",
+    "website_url": "https://github.com/Andrii-Grytsenko-OWASP/SnykVulnCheck",
+    "capabilities": [
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/socket.json
+++ b/tools/socket.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Socket",
+    "publisher": "Socket",
+    "description": "Supply Chain Security platform. Next-gen SCA + SBOM + 0-day prevention.",
+    "website_url": "https://socket.dev",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION",
+      "GITHUB_APP",
+      "GITLAB_CI_TEMPLATE"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "DESIGN",
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "C/C++",
+      ".NET",
+      "ERLANG_ELIXIR",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "KOTLIN",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SCALA",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/software_assurance_guardian_point_man.json
+++ b/tools/software_assurance_guardian_point_man.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Software Assurance Guardian Point Man",
+    "publisher": "Reliable Energy Analytics LLC",
+    "description": "A patented tool that performs comprehensive software supply chain risk assessments using a 7-step process to detect vulnerabilities and calculate trustworthiness scores for software.",
+    "website_url": "https://reliableenergyanalytics.com/products",
+    "repository_url": "https://reliableenergyanalytics.com/products",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/sonar_cryptography_plugin.json
+++ b/tools/sonar_cryptography_plugin.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Sonar Cryptography Plugin",
+    "publisher": "IBM",
+    "description": "A SonarQube Plugin that detects cryptographic assets in source code and generates CBOM.",
+    "repository_url": "https://github.com/IBM/sonar-cryptography",
+    "website_url": "https://github.com/IBM/sonar-cryptography",
+    "capabilities": [
+      "CBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "JENKINS_PLUGIN"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/sonarqube.json
+++ b/tools/sonarqube.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SonarQube",
+    "publisher": "SonarSource",
+    "description": "SonarQube allows developers and development teams to write clean code and remediate existing code organically, so they can focus on the work they love and maximize the value they generate for businesses.",
+    "repository_url": "https://github.com/SonarSource/sonarqube",
+    "website_url": "https://www.sonarsource.com/products/sonarqube/",
+    "availability": [
+      "OPEN_SOURCE",
+      "FREEMIUM",
+      "COMMERCIAL_LICENSE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "SWIFT",
+      "SCALA",
+      "KOTLIN"
+    ]
+  }
+}

--- a/tools/sonarqube_advanced_security.json
+++ b/tools/sonarqube_advanced_security.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SonarQube Advanced Security",
+    "publisher": "Sonar",
+    "description": "Secure your entire codebase\u2014first-party, third-party, and everything in between. Seamlessly integrated into your workflow, SonarQube detects and fixes vulnerabilities, ensures license compliance, and generates Software Bills of Materials",
+    "website_url": "https://sonarsource.com/solutions/security",
+    "capabilities": [
+      "SBOM",
+      "CDXA"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS",
+      "POLICY_EVALUATION",
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "AZURE_PIPELINE_EXTENSION",
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "GITLAB_CI_TEMPLATE",
+      "JENKINS_PLUGIN",
+      "MAVEN_PLUGIN"
+    ],
+    "library": [
+      "JAVA",
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      ".NET",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "KOTLIN",
+      "NODE.JS",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SCALA"
+    ]
+  }
+}

--- a/tools/sonatype_lift.json
+++ b/tools/sonatype_lift.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Sonatype Lift",
+    "publisher": "Sonatype",
+    "description": "Cloud-native, collaborative code analysis platform that analyzes pull requests to find and fix security, performance, reliability, and style issues while generating CycloneDX SBOMs.",
+    "website_url": "https://lift.sonatype.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE",
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [],
+    "packaging": [
+      "GITHUB_APP",
+      "APPLICATION"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "GO",
+      "PHP",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/soos.json
+++ b/tools/soos.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SOOS",
+    "publisher": "SOOS",
+    "description": "Automate your software inventory. SOOS creates, ingests, and manages your Software Bill of Materials and uses patented SCA and the largest open-source SBOM database to find hidden vulnerabilities, license issues, and dependencies sooner.",
+    "website_url": "https://soos.io",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "DISTRIBUTE",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "GITHUB_ACTION",
+      "GITHUB_APP",
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "JAVA",
+      ".NET",
+      "PYTHON",
+      "RUBY",
+      "PHP"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "JAVA",
+      "PYTHON",
+      "RUBY",
+      "PHP"
+    ]
+  }
+}

--- a/tools/spack.json
+++ b/tools/spack.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Spack",
+    "publisher": "Spack",
+    "description": "HPC package manager for Linux and macOS; the spack-sbom plug-in exports CycloneDX SBOMs for any concretized spec.",
+    "repository_url": "https://github.com/spack/spack-sbom",
+    "website_url": "https://spack.io/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "FORTRAN",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "RUST",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/spdxcyclone.json
+++ b/tools/spdxcyclone.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "spdxcyclone",
+    "publisher": "SPDX",
+    "description": "Java utility that converts Software Bill of Materials (SBOM) documents from CycloneDX format to SPDX format, supporting multiple serialization options for both standards.",
+    "repository_url": "https://github.com/spdx/cdx2spdx",
+    "website_url": "https://github.com/spdx/cdx2spdx",
+    "capabilities": [],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/spectra_assure.json
+++ b/tools/spectra_assure.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Spectra Assure",
+    "publisher": "ReversingLabs",
+    "description": "Spectra Assure scans binary software packages, container images, and VM disk images to detect malware, tampering, vulnerabilities, and other exposures. CycloneDX SBOM, SaaSBOM, ML-BOM, and CBOM are outputs.",
+    "repository_url": "https://github.com/reversinglabs/spectra-assure-sdk",
+    "website_url": "https://www.reversinglabs.com/products/software-supply-chain-security",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "CBOM",
+      "AI/ML-BOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "GITLAB_CI_TEMPLATE",
+      "AZURE_PIPELINE_EXTENSION",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CPE",
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PYTHON",
+      "PHP",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/src_clr_sbom_generator.json
+++ b/tools/src_clr_sbom_generator.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SRC:CLR SBOM Generator",
+    "publisher": "Veracode",
+    "description": "Generates a Software Bill of Materials in CycloneDX JSON Format from Veracode SCA Agent results",
+    "repository_url": "https://github.com/veracode/srcclr_sbom_gen",
+    "website_url": "https://github.com/veracode/srcclr_sbom_gen",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "transform": [
+      "BOM_STANDARD"
+    ]
+  }
+}

--- a/tools/stackaware.json
+++ b/tools/stackaware.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "StackAware",
+    "publisher": "StackAware",
+    "description": "StackAware is a SaaS platform for managing CycloneDX 1.4/1.5 and SPDX SBOMs, enriching them with VEX data, and securely distributing both SBOMs and SaaSBOMs for supply-chain risk analysis.",
+    "website_url": "https://stackaware.com/",
+    "capabilities": [
+      "SBOM",
+      "SAASBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/sunshine.json
+++ b/tools/sunshine.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Sunshine",
+    "publisher": "CycloneDX",
+    "description": "Open-source SBOM visualization tool. Converts CycloneDX JSON into interactive charts and tables for components, dependencies, vulnerabilities, and licenses.",
+    "website_url": "https://cyclonedx.github.io/Sunshine/",
+    "repository_url": "https://github.com/CycloneDX/Sunshine/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedLanguages": [
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/surfactant.json
+++ b/tools/surfactant.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Surfactant",
+    "publisher": "LLNL",
+    "description": "A modular framework for extracting file information and relationships for filesystems, with an SBOM as the primary output.",
+    "repository_url": "https://github.com/LLNL/Surfactant",
+    "website_url": "https://github.com/LLNL/Surfactant",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "LIBRARY",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "PYTHON"
+    ]
+  }
+}

--- a/tools/swift_package_sbom_generator.json
+++ b/tools/swift_package_sbom_generator.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "swift-package-sbom-generator",
+    "publisher": "Mattt",
+    "description": "A software bill of materials (SBOM) generator for Swift packages",
+    "repository_url": "https://github.com/mattt/swift-package-sbom",
+    "website_url": "https://github.com/mattt/swift-package-sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "SWIFT"
+    ],
+    "platform": [
+      "MAC"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/swiftbom.json
+++ b/tools/swiftbom.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SwiftBOM",
+    "publisher": "CERT Coordination Center (CERT/CC)",
+    "description": "Generates SBOMs for demo and PoC purposes. Supports output in CycloneDX, SPDX, and SWID formats. Visualizes SBOMs as tree graphs.",
+    "repository_url": "https://github.com/CERTCC/SBOM",
+    "website_url": "https://sbom.democert.org/sbom/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SWID"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/syft.json
+++ b/tools/syft.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Syft",
+    "publisher": "Anchore",
+    "description": "CLI tool and library for generating a Software Bill of Materials from container images and filesystems.",
+    "repository_url": "https://github.com/anchore/syft",
+    "website_url": "https://anchore.github.io/syft/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "RESOURCE_REPORTING",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT",
+      "BOM_STANDARD",
+      "BOM_VERSION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/tally.json
+++ b/tools/tally.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Tally",
+    "publisher": "Jetstack",
+    "description": "Command-line tool that adds OpenSSF Scorecard security posture scores to packages listed in CycloneDX SBOMs.",
+    "repository_url": "https://github.com/jetstack/tally",
+    "website_url": "https://github.com/jetstack/tally",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}

--- a/tools/technolinator.json
+++ b/tools/technolinator.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Technolinator",
+    "publisher": "MediaMarktSaturn Technology",
+    "description": "GitHub App that generates CycloneDX SBOMs with cdxgen, scans them for vulnerabilities using grype, and uploads results to Dependency-Track.",
+    "repository_url": "https://github.com/MediaMarktSaturn/technolinator",
+    "website_url": "https://github.com/MediaMarktSaturn/technolinator",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "GITHUB_APP",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}

--- a/tools/tern.json
+++ b/tools/tern.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Tern",
+    "publisher": "Tern",
+    "description": "Software composition analysis tool that generates a Software Bill of Materials for container images and Dockerfiles",
+    "repository_url": "https://github.com/tern-tools/tern",
+    "website_url": "https://github.com/tern-tools/tern",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/threatmapper.json
+++ b/tools/threatmapper.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ThreatMapper",
+    "publisher": "Deepfence",
+    "description": "Deepfence ThreatMapper hunts for vulnerabilities in production platforms, ranks vulnerabilities based on their risk-of-exploit using attack path enumeration, and generates CycloneDX SBOMs.",
+    "repository_url": "https://github.com/deepfence/threatmapper",
+    "website_url": "https://deepfence.io/threatmapper",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "CONTAINER_IMAGE",
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/threatrix.json
+++ b/tools/threatrix.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Threatrix",
+    "publisher": "Threatrix",
+    "description": "Threatrix CodeCertify platform provides a solution for producing a comprehensive and accurate, singular, CycloneDX bill of materials from multiple sources.",
+    "website_url": "https://threatrix.io",
+    "repository_url": "https://threatrix.io",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "GITHUB_APP",
+      "GITHUB_ACTION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PERL",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SWIFT",
+      "ERLANG_ELIXIR",
+      "SCALA",
+      "KOTLIN",
+      "GROOVY",
+      "FORTRAN",
+      "NIM"
+    ]
+  }
+}

--- a/tools/tidelift.json
+++ b/tools/tidelift.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Tidelift",
+    "publisher": "Tidelift",
+    "description": "Tidelift provides a managed open-source subscription that delivers commercial support, maintenance, security and license assurances for the open-source dependencies used to build applications, backed directly by project maintainers.",
+    "repository_url": "https://github.com/tidelift",
+    "website_url": "https://tidelift.com/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY",
+      "GITHUB_ACTION",
+      "GITLAB_CI_TEMPLATE"
+    ],
+    "library": [],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "SWIFT",
+      "GO",
+      "RUST",
+      ".NET",
+      "RUBY",
+      "NODE.JS"
+    ]
+  }
+}

--- a/tools/trivy.json
+++ b/tools/trivy.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Trivy",
+    "publisher": "Aqua Security",
+    "description": "Comprehensive security scanner for containers, filesystems, Git repositories, VMs and Kubernetes that detects vulnerabilities, misconfigurations, secrets and generates CycloneDX SBOMs.",
+    "repository_url": "https://github.com/aquasecurity/trivy",
+    "website_url": "https://trivy.dev/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL",
+      "CPE"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST"
+    ]
+  }
+}

--- a/tools/trustsource.json
+++ b/tools/trustsource.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "TrustSource",
+    "publisher": "TrustSource",
+    "description": "SaaS platform for implementing and maintaining open source compliance that imports CycloneDX SBOMs, analyzes them for licenses and vulnerabilities, and integrates with various development workflows.",
+    "repository_url": "https://github.com/trustsource",
+    "website_url": "https://www.trustsource.io/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "PYTHON",
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PYTHON",
+      "RUBY"
+    ]
+  }
+}

--- a/tools/ts_scan.json
+++ b/tools/ts_scan.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ts-scan",
+    "publisher": "TrustSource",
+    "description": "Multi ecosystem SCA cli tool supporting SBOM generation, decoration and analysis for licenses, vulnerabilities, known code snippets and malware.",
+    "repository_url": "https://github.com/TrustSource/ts-scan",
+    "website_url": "https://trustsource.github.io/ts-scan/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "TRANSFORM",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "C/C++",
+      "GO",
+      ".NET"
+    ]
+  }
+}

--- a/tools/valaa_stack.json
+++ b/tools/valaa_stack.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Valaa Stack",
+    "publisher": "Valaa Technologies",
+    "description": "SBoMDoc is a VDoc extension which uses CycloneDX namespaces and can emit BOM documents in various formats",
+    "repository_url": "https://github.com/valaatech/kernel",
+    "website_url": "https://valospace.org/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "TRANSFORM"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT"
+    ]
+  }
+}

--- a/tools/valint.json
+++ b/tools/valint.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Valint",
+    "publisher": "Scribe Security",
+    "description": "CLI and CI/CD tool for generating CycloneDX SBOMs, signing and verifying supply-chain evidence, enforcing policy, and tracking vulnerabilities across containers, source repositories, and pipelines.",
+    "repository_url": "https://github.com/scribe-security/gatekeeper-valint",
+    "website_url": "https://scribesecurity.com/scribe-platform-lp",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "SIGNING/NOTARY",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "AZURE_PIPELINE_EXTENSION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ]
+  }
+}

--- a/tools/value_stream_management_vsm_.json
+++ b/tools/value_stream_management_vsm_.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Value Stream Management (VSM)",
+    "publisher": "LeanIX",
+    "description": "SaaS catalog that ingests CycloneDX SBOMs via REST API, indexes them by team and product, and surfaces vulnerabilities, licenses and component age to secure the software supply chain.",
+    "website_url": "https://www.leanix.net/en/products/value-stream-management",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS",
+      "POLICY_EVALUATION"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}

--- a/tools/veracode.json
+++ b/tools/veracode.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Veracode",
+    "publisher": "Veracode",
+    "description": "API to output SBOM in CycloneDX (JSON) format based on Veracode's software composition analysis (SCA) scan.",
+    "website_url": "https://www.veracode.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "APPLICATION",
+      "GITHUB_ACTION"
+    ],
+    "library": [],
+    "platform": [
+      "WINDOWS",
+      "MAC",
+      "LINUX"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "PYTHON",
+      "RUBY",
+      "GO",
+      "PHP"
+    ]
+  }
+}

--- a/tools/vexy.json
+++ b/tools/vexy.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Vexy",
+    "publisher": "Paul Horton",
+    "description": "Generate VEX (Vulnerability Exploitability Exchange) CycloneDX documents.",
+    "repository_url": "https://github.com/madpah/vexy",
+    "website_url": "https://github.com/madpah/vexy",
+    "capabilities": [
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": []
+  }
+}

--- a/tools/vigiles.json
+++ b/tools/vigiles.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Vigiles",
+    "publisher": "Timesys",
+    "description": "Vulnerability monitoring and remediation suite that imports, generates, converts, and analyses CycloneDX or SPDX SBOMs with curated CVE feeds and build-system integrations for Yocto, Buildroot, OpenWrt, and more.",
+    "repository_url": "https://github.com/TimesysGit/vigiles-cli",
+    "website_url": "https://www.timesys.com/solutions/vigiles-vulnerability-management/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "transform": [
+      "BOM_STANDARD"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": []
+  }
+}

--- a/tools/vsm_sbom_booster.json
+++ b/tools/vsm_sbom_booster.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "vsm-sbom-booster",
+    "publisher": "LeanIX",
+    "description": "CLI and Docker-based tool that scans Git providers, runs ORT, generates CycloneDX SBOMs centrally, and uploads them to LeanIX VSM to speed onboarding.",
+    "repository_url": "https://github.com/leanix/vsm-sbom-booster",
+    "website_url": "https://github.com/leanix/vsm-sbom-booster",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION",
+      "DISTRIBUTE"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "KOTLIN"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "C/C++",
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      ".NET",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "KOTLIN",
+      "SCALA",
+      "SWIFT"
+    ]
+  }
+}

--- a/tools/vulert_vulnerability_scanner.json
+++ b/tools/vulert_vulnerability_scanner.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Vulert Vulnerability Scanner",
+    "publisher": "Vulert.com",
+    "description": "Web SCA service that analyzes CycloneDX or SPDX SBOMs (or lockfiles) to flag open-source vulnerabilities and license issues, sending real-time alerts without requiring code access or signup.",
+    "website_url": "https://vulert.com/abom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/vulnerabilities_io.json
+++ b/tools/vulnerabilities_io.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Vulnerabilities.io",
+    "publisher": "Vulnerabilities Input Output Limited",
+    "description": "Generates CycloneDX Software Bill of Materials (SBOM) and visualizations for an organization's codebase through integrations with source control systems. Enables organizations to manage overall supply chain risk.",
+    "website_url": "https://www.vulnerabilities.io",
+    "repository_url": "https://www.vulnerabilities.io",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "GITHUB_APP",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      ".NET",
+      "PHP",
+      "PYTHON",
+      "JAVASCRIPT/TYPESCRIPT",
+      "RUST",
+      "ERLANG_ELIXIR"
+    ]
+  }
+}

--- a/tools/vuls.json
+++ b/tools/vuls.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Vuls",
+    "publisher": "Future Corp",
+    "description": "Agent-less vulnerability scanner for Linux, FreeBSD, containers, WordPress, programming language libraries and network devices which outputs CycloneDX Vulnerability Disclosure Reports (VDR).",
+    "repository_url": "https://github.com/future-architect/vuls",
+    "website_url": "https://vuls.io/",
+    "capabilities": [
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ]
+  }
+}

--- a/tools/wpbom.json
+++ b/tools/wpbom.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "WpBom",
+    "publisher": "Sepbit",
+    "description": "WordPress plugin that generates CycloneDX SBOMs for installed plugins and themes, and can automatically submit them to OWASP Dependency-Track for vulnerability analysis.",
+    "repository_url": "https://github.com/sepbit/wpbom",
+    "website_url": "https://wordpress.org/plugins/wpbom/",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [],
+    "transform": [
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "APPLICATION"
+    ],
+    "library": [
+      "PHP"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "PHP"
+    ]
+  }
+}

--- a/tools/xray.json
+++ b/tools/xray.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Xray",
+    "publisher": "JFrog",
+    "description": "JFrog Xray is a software-composition-analysis platform that finds vulnerabilities, license issues and policy violations in open-source and third-party components, and can export CycloneDX SBOMs with optional VEX data.",
+    "website_url": "https://jfrog.com/xray/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "DISTRIBUTE"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING"
+    ],
+    "transform": [
+      "BOM_STANDARD",
+      "BOM_SERIALIZATION_FORMAT"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "AZURE_PIPELINE_EXTENSION"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "CPE"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "GO",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "C/C++",
+      "PHP"
+    ]
+  }
+}

--- a/tools/xygeni_software_supply_chain_security.json
+++ b/tools/xygeni_software_supply_chain_security.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Xygeni Software Supply-Chain Security",
+    "publisher": "Xygeni",
+    "description": "Supply-chain security platform and CLI that generates CycloneDX SBOMs, analyses vulnerabilities and misconfigurations, enforces policy in CI/CD, and integrates with DevOps tools to secure releases.",
+    "repository_url": "https://github.com/xygeni/xygeni-action",
+    "website_url": "https://xygeni.io/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS",
+      "DISTRIBUTE",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "POLICY_EVALUATION",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION",
+      "JENKINS_PLUGIN"
+    ],
+    "library": [
+      "JAVA"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4"
+    ],
+    "supportedLanguages": [
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "PYTHON",
+      "GO",
+      ".NET"
+    ]
+  }
+}

--- a/tools/yasca_yet_another_sca_tool_.json
+++ b/tools/yasca_yet_another_sca_tool_.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "yasca (Yet Another SCA tool)",
+    "publisher": "Javi",
+    "description": "Yasca (Yet Another SCA tool) is an open-source Python utility and GitHub Action that scans Maven projects against GitHub Security Advisories, detects vulnerable or outdated dependencies, and exports CycloneDX SBOMs.",
+    "repository_url": "https://github.com/javixeneize/zasca",
+    "website_url": "https://github.com/javixeneize/zasca",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "PYTHON"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [],
+    "supportedLanguages": [
+      "JAVA"
+    ]
+  }
+}


### PR DESCRIPTION
fixes #67
- a new `tool.schema.json` was created 
- the `tools.json` was split into individual files in the `tools/` folder
- each file in the `tools/` folder follows the new `tool.schema.json`
- added automated validators for the files in the `tools/` folder
- added automated processes that assemble the `tools.json` based on all files in the `tools/` folder
- modified the metaconfigurator config and links to easy file modifications
- created helpers to split and assemble the `tools.json`

result: 
- we still maintain the `tools.json` file
- we have separate files for each tool, so that it is easy to add/modify tools in parallel