### PR TITLE
Add FuseSoC (FPGA IP manager with SBOM generation)

### DIFF
--- a/tools/fusesoc.json
+++ b/tools/fusesoc.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "FuseSoC",
+    "description": "Package manager and build tool for FPGA and HDL projects, including SPDX SBOM generation from IP metadata.",
+    "publisher": "Olof Kindgren",
+    "repository_url": "https://github.com/olofk/fusesoc",
+    "website_url": "https://fusesoc.net",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "supportedStandards": [
+      "PACKAGE_URL",
+      "SPDX"
+    ]
+  }
+}

--- a/tools/fusesoc.json
+++ b/tools/fusesoc.json
@@ -14,7 +14,6 @@
       "OPEN_SOURCE"
     ],
     "functions": [
-      "AUTHOR",
       "PACKAGE_MANAGER_INTEGRATION"
     ],
     "supportedStandards": [


### PR DESCRIPTION
FuseSoC is the leading package manager for FPGA/ASIC and also supports generating SBOMs.