### PR TITLE
Add depguard

### DIFF
--- a/tools/depguard.json
+++ b/tools/depguard.json
@@ -17,7 +17,6 @@
     ],
     "functions": [
       "ANALYSIS",
-      "AUTHOR"
     ],
     "analysis": [
       "SECURITY_VULNERABILITIES",

--- a/tools/depguard.json
+++ b/tools/depguard.json
@@ -16,7 +16,7 @@
       "OSI_APPROVED"
     ],
     "functions": [
-      "ANALYSIS",
+      "ANALYSIS"
     ],
     "analysis": [
       "SECURITY_VULNERABILITIES",

--- a/tools/depguard.json
+++ b/tools/depguard.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "depguard",
+    "publisher": "Jorge Morais",
+    "description": "MCP security server for AI coding agents. Generates CycloneDX 1.6 SBOMs with optional VEX, audits npm packages against npm and GitHub advisories, scans tarballs for supply-chain attacks, and acts as a pre-install guardian. Zero runtime dependencies.",
+    "repository_url": "https://github.com/mopanc/depguard",
+    "website_url": "https://depguard.dev",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "OUTDATED_COMPONENTS"
+    ],
+    "transform": [],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "LIBRARY"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT",
+      "NODE.JS"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS"
+    ]
+  }
+}


### PR DESCRIPTION
### Tool: depguard

**depguard** is an MCP (Model Context Protocol) security server for AI coding agents that generates CycloneDX 1.6 SBOMs and audits npm dependencies. Released under Apache-2.0.

- Repository: https://github.com/mopanc/depguard
- Website: https://depguard.dev
- npm: https://www.npmjs.com/package/depguard-cli
- Latest release: https://github.com/mopanc/depguard/releases/tag/v1.9.0

### SBOM-relevant capabilities

- **CycloneDX 1.6 SBOM generation** with PURLs (`pkg:npm/...`), SHA-512 integrity hashes, and full dependency graph from `package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` / `bun.lock`.
- **VEX support**, vulnerabilities detected by the audit pipeline (npm + GitHub Advisory Database) embed inline in the BOM with GHSA/CVE IDs, CVSS ratings, CWEs, and patched-version recommendations.
- **Native implementation**, depguard ships with **zero runtime dependencies** as a deliberate product principle. The CycloneDX serializer is implemented in TypeScript directly against the public CycloneDX 1.6 JSON Schema rather than via `@cyclonedx/cyclonedx-library`. Output is validated against the official CycloneDX validators in CI.
- Compliance-oriented: targets EU Cyber Resilience Act, US EO 14028 / OMB M-22-18, SOC 2, FedRAMP supplier requirements.

### Quick try

```
npm install -g depguard-cli
depguard-cli sbom ./package.json -o sbom.cdx.json
```

### Background

This submission was suggested by @jkowalleck on https://github.com/mopanc/depguard/issues/10 once CycloneDX support was finalized, that landed in v1.9.0.

The metadata in `tools/depguard.json` validates cleanly against `schemas/tool.schema.json`.
