### PR TITLE
Add PHP parser

### DIFF
--- a/tools/parser_php.json
+++ b/tools/parser_php.json
@@ -1,0 +1,43 @@
+{
+	"specVersion": "2.0",
+	"tool": {
+		"name": "CycloneDX SBOM Parser for PHP",
+		"publisher": "Martin Adler",
+		"description": "Type-safe, read-only PHP library for parsing CycloneDX SBOM JSON files. Supports CycloneDX 1.4+ including components, vulnerabilities, and metadata. Built for application code that needs to consume existing SBOM files.",
+		"repository_url": "https://github.com/mteu/sbom-parser",
+		"capabilities": [
+			"SBOM"
+		],
+		"availability": [
+			"OPEN_SOURCE",
+			"OSI_APPROVED"
+		],
+		"functions": [
+			"ANALYSIS"
+		],
+		"packaging": [
+			"LIBRARY"
+		],
+		"library": [
+			"PHP"
+		],
+		"platform": [
+			"LINUX",
+			"MAC",
+			"WINDOWS"
+		],
+		"lifecycle": [
+			"POST-BUILD",
+			"OPERATIONS"
+		],
+		"supportedStandards": [
+			"CYCLONEDX"
+		],
+		"cycloneDxVersion": [
+			"CYCLONEDX_V1.4",
+			"CYCLONEDX_V1.5",
+			"CYCLONEDX_V1.6",
+			"CYCLONEDX_V1.7"
+		]
+	}
+}


### PR DESCRIPTION
CycloneDX SBOM (Software Bill of Materials) parser for PHP 8.3+. Supports [CycloneDX 1.4+ specifications](https://github.com/CycloneDX/specification) including components, vulnerabilities, and metadata with full immutable entity design using Valinor for type mapping.

The CycloneDX ecosystem provides an official PHP library ([cyclonedx/cyclonedx-library](https://github.com/CycloneDX/cyclonedx-php-library)) and a [Composer plugin](https://github.com/CycloneDX/cyclonedx-php-composer) for generating SBOMs. These tools are designed to produce BOMs as part of your build pipeline — not for consuming them in application code.

This package aims to fill a different gap: Reading and inspecting existing SBOM files.

If your application needs to parse a CycloneDX SBOM and work with its data — querying components, checking vulnerabilities, reading metadata — you need a lightweight, read-only library with clean, type-safe objects. That is what this package aims to provide.