### PR TITLE
Add Swarm Orchestrator to Tool Center

### DIFF
--- a/tools/swarm_orchestrator.json
+++ b/tools/swarm_orchestrator.json
@@ -6,16 +6,13 @@
     "publisher": "Brad Kinnard",
     "description": "Audits AI-generated pull requests for cheat patterns and emits CycloneDX-ML and SPDX 3.0 AI-Profile (AI-BOM) artifacts for EU AI Act and CISA SBOM-for-AI documentation.",
     "repository_url": "https://github.com/moonrunnerkc/swarm-orchestrator",
-    "website_url": "https://www.npmjs.com/package/swarm-orchestrator",
+    "website_url": "https://github.com/moonrunnerkc/swarm-orchestrator#readme",
     "capabilities": [
       "AI/ML-BOM",
       "SBOM"
     ],
     "availability": [
       "OPEN_SOURCE"
-    ],
-    "functions": [
-      "AUTHOR"
     ],
     "library": [
       "NODE.JS"

--- a/tools/swarm_orchestrator.json
+++ b/tools/swarm_orchestrator.json
@@ -27,6 +27,9 @@
       "CYCLONEDX",
       "SPDX"
     ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
     "packaging": [
       "GITHUB_ACTION",
       "COMMAND_LINE_UTILITY"

--- a/tools/swarm_orchestrator.json
+++ b/tools/swarm_orchestrator.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Swarm Orchestrator",
+    "publisher": "Brad Kinnard",
+    "description": "Audits AI-generated pull requests for cheat patterns and emits CycloneDX-ML and SPDX 3.0 AI-Profile (AI-BOM) artifacts for EU AI Act and CISA SBOM-for-AI documentation.",
+    "repository_url": "https://github.com/moonrunnerkc/swarm-orchestrator",
+    "website_url": "https://www.npmjs.com/package/swarm-orchestrator",
+    "capabilities": [
+      "AI/ML-BOM",
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "AUTHOR"
+    ],
+    "library": [
+      "NODE.JS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "packaging": [
+      "GITHUB_ACTION",
+      "COMMAND_LINE_UTILITY"
+    ]
+  }
+}


### PR DESCRIPTION
Adds Swarm Orchestrator, an open-source (ISC) GitHub Action and CLI that emits CycloneDX-ML and SPDX 3.0 AI-Profile (AI-BOM) artifacts for EU AI Act and CISA SBOM-for-AI documentation while auditing AI-generated pull requests. Added as a single file in tools/ per the contributing guidelines, validated against the v2 tool schema. The metadata is accurate, and the tool is ISC licensed.