### PR TITLE
Add cyclonedx-cr to Tool Center

### DIFF
--- a/tools/cyclonedx-cr.json
+++ b/tools/cyclonedx-cr.json
@@ -14,7 +14,6 @@
       "OSI_APPROVED"
     ],
     "functions": [
-      "AUTHOR",
       "PACKAGE_MANAGER_INTEGRATION"
     ],
     "packaging": [

--- a/tools/cyclonedx-cr.json
+++ b/tools/cyclonedx-cr.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cyclonedx-cr",
+    "publisher": "hahwul",
+    "description": "A Crystal tool for generating CycloneDX SBOMs from Crystal shard projects, reading shard.yml and shard.lock to produce JSON, XML, or CSV output with canonical PURLs.",
+    "repository_url": "https://github.com/hahwul/cyclonedx-cr",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "AUTHOR",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE",
+      "LIBRARY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}


### PR DESCRIPTION
Hey, I just added cyclonedx-cr to the tools list. It's a Crystal CLI that generates CycloneDX SBOMs from crystal-lang projects, basically turns `shard.yml` and `shard.lock` into JSON, XML, or CSV with PURLs. 
MIT licensed, and the repo is at https://github.com/hahwul/cyclonedx-cr.

I added it as a single file `tools/cyclonedx-cr.json` following the contributing guidelines, and validated it with `check-jsonschema`. One small thing.. I left out the `library` and `supportedLanguages` fields since Crystal isn't in the schema enums yet.