### PR TITLE
Add BomLens

### DIFF
--- a/tools/bomlens.json
+++ b/tools/bomlens.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+    "specVersion": "2.0",
+    "tool": {
+        "name": "BomLens",
+        "publisher": "SK Telecom",
+        "description": "Local-first (no-SaaS) SBOM generator and open source risk assessor. CycloneDX SBOMs, AI ML-BOMs with G7 conformance checks, NOTICE files, and security/license risk reports from source, containers, binaries, firmware, AI models, and ingested SBOMs.",
+        "repository_url": "https://github.com/sktelecom/sbom-tools",
+        "website_url": "https://sktelecom.github.io/sbom-tools/",
+        "capabilities": [
+            "AI/ML-BOM",
+            "SBOM"
+        ],
+        "availability": [
+            "OPEN_SOURCE"
+        ],
+        "functions": [
+            "AUTHOR",
+            "ANALYSIS"
+        ],
+        "analysis": [
+            "LICENSE_REPORTING",
+            "SECURITY_VULNERABILITIES"
+        ],
+        "packaging": [
+            "APPLICATION",
+            "COMMAND_LINE_UTILITY",
+            "CONTAINER_IMAGE"
+        ],
+        "platform": [
+            "LINUX",
+            "MAC",
+            "WINDOWS"
+        ],
+        "lifecycle": [
+            "BUILD",
+            "POST-BUILD",
+            "OPERATIONS"
+        ],
+        "supportedStandards": [
+            "CPE",
+            "CYCLONEDX",
+            "PACKAGE_URL",
+            "SPDX"
+        ],
+        "cycloneDxVersion": [
+            "CYCLONEDX_V1.7",
+            "CYCLONEDX_V1.6"
+        ],
+        "supportedLanguages": [
+            "C/C++",
+            ".NET",
+            "GO",
+            "JAVA",
+            "JAVASCRIPT/TYPESCRIPT",
+            "NODE.JS",
+            "PHP",
+            "PYTHON",
+            "RUBY",
+            "RUST",
+            "SWIFT"
+        ]
+    }
+}

--- a/tools/bomlens.json
+++ b/tools/bomlens.json
@@ -4,7 +4,7 @@
     "tool": {
         "name": "BomLens",
         "publisher": "SK Telecom",
-        "description": "Local-first (no-SaaS) SBOM generator and open source risk assessor. CycloneDX SBOMs, AI ML-BOMs with G7 conformance checks, NOTICE files, and security/license risk reports from source, containers, binaries, firmware, AI models, and ingested SBOMs.",
+        "description": "Generates CycloneDX SBOMs from source code, containers, binaries, firmware, and HuggingFace AI models. Ingests existing CycloneDX/SPDX SBOMs and produces license and security findings and NOTICE files. CLI, web UI, and desktop app.",
         "repository_url": "https://github.com/sktelecom/sbom-tools",
         "website_url": "https://sktelecom.github.io/sbom-tools/",
         "capabilities": [
@@ -15,12 +15,15 @@
             "OPEN_SOURCE"
         ],
         "functions": [
-            "AUTHOR",
-            "ANALYSIS"
+            "ANALYSIS",
+            "TRANSFORM"
         ],
         "analysis": [
             "LICENSE_REPORTING",
             "SECURITY_VULNERABILITIES"
+        ],
+        "transform": [
+            "BOM_STANDARD"
         ],
         "packaging": [
             "APPLICATION",


### PR DESCRIPTION
Adds BomLens by SK Telecom — a local-first, open source (Apache-2.0) SBOM generator and open source risk assessor. It produces CycloneDX SBOMs and AI ML-BOMs (with G7 minimum-elements conformance checks), NOTICE files, and security/license risk reports from source code, container images, binaries, firmware, HuggingFace AI models, and ingested SBOMs, via CLI, web UI, and a desktop app.

- Repository: https://github.com/sktelecom/sbom-tools
- Docs: https://sktelecom.github.io/sbom-tools/

The entry validates against `schemas/tool.schema.json`.