### PR TITLE
Add Lucent Sky AVM

### DIFF
--- a/tools/lucent_sky_avm.json
+++ b/tools/lucent_sky_avm.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Lucent Sky AVM",
+    "publisher": "Lucent Sky",
+    "description": "Scans binaries, source code, dependencies, and existing SBOMs to identify and remediate known and unknown vulnerabilities. Generates CycloneDX and SPDX SBOMs to support compliance and supply chain transparency.",
+    "website_url": "https://www.lucentsky.com/",
+    "capabilities": [
+      "SBOM",
+      "VDR/VEX"
+    ],
+    "availability": [
+      "SUBSCRIPTION",
+      "COMMERCIAL_LICENSE"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION",
+      "OUTDATED_COMPONENTS"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD",
+      "BUILD",
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL",
+      "CPE"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      ".NET",
+      "C/C++",
+      "GO",
+      "GROOVY",
+      "JAVA",
+      "JAVASCRIPT/TYPESCRIPT",
+      "KOTLIN",
+      "NODE.JS",
+      "PHP",
+      "PYTHON",
+      "RUBY",
+      "RUST",
+      "SCALA",
+      "SWIFT"
+    ]
+  }
+}


### PR DESCRIPTION
Add Lucent Sky AVM, a SAST/SCA tool that can ingest and generate CycloneDX SBOMs.

#### SBOM-relevant capabilities
- Generates SBOMs with identified software components after binary/source code analysis
- Ingests supplier-provided SBOMs for dependency management, vulnerability analysis, and license discovery

The metadata in `tools/lucent_sky_avm.json` validates against `schemas/tool.schema.json`.