### PR TITLE
Add GLaaS to tool center

### DIFF
--- a/tools/glaas.json
+++ b/tools/glaas.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "GLaaS",
+    "publisher": "TReqs Inc.",
+    "description": "GLaaS (Global Lineage-as-a-Service) pairs with the open-source roar CLI to trace ML pipeline lineage and generate CycloneDX 1.7 AI-BOMs, scored for completeness against G7, CISA, and NTIA SBOM-for-AI minimum elements.",
+    "repository_url": "https://github.com/treqs/roar",
+    "website_url": "https://glaas.ai",
+    "capabilities": [
+      "AI/ML-BOM"
+    ],
+    "availability": [
+      "FREEMIUM",
+      "SUBSCRIPTION"
+    ],
+    "functions": [
+      "AUTHOR",
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "LICENSE_REPORTING",
+      "POLICY_EVALUATION",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "APPLICATION"
+    ],
+    "library": [
+      "PYTHON",
+      "RUST"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC"
+    ],
+    "lifecycle": [
+      "BUILD",
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.7"
+    ]
+  }
+}

--- a/tools/glaas.json
+++ b/tools/glaas.json
@@ -4,7 +4,7 @@
   "tool": {
     "name": "GLaaS",
     "publisher": "TReqs Inc.",
-    "description": "GLaaS (Global Lineage-as-a-Service) pairs with the open-source roar CLI to trace ML pipeline lineage and generate CycloneDX 1.7 AI-BOMs, scored for completeness against G7, CISA, and NTIA SBOM-for-AI minimum elements.",
+    "description": "GLaaS (Global Lineage-as-a-Service) pairs with the open-source `roar` CLI to trace ML pipeline lineage and generate CycloneDX 1.7 AI-BOMs, scored for completeness against G7, CISA, and NTIA SBOM-for-AI minimum elements.",
     "repository_url": "https://github.com/treqs/roar",
     "website_url": "https://glaas.ai",
     "capabilities": [
@@ -15,8 +15,8 @@
       "SUBSCRIPTION"
     ],
     "functions": [
-      "AUTHOR",
-      "ANALYSIS"
+      "ANALYSIS",
+      "DISTRIBUTE"
     ],
     "analysis": [
       "LICENSE_REPORTING",


### PR DESCRIPTION
## Summary
- Adds GLaaS (Global Lineage-as-a-Service) to the tool center.
- GLaaS pairs with the open-source [roar CLI](https://github.com/treqs/roar) to trace ML pipeline lineage and generate CycloneDX 1.7 AI-BOMs, scored for completeness against G7, CISA, and NTIA SBOM-for-AI minimum elements.
- For more details, see [glaas.ai](https://glaas.ai), https://pypi.org/project/roar-cli/ and [treqs.ai](https://treqs.ai)
- Validated `tools/glaas.json` against `schemas/tool.schema.json` with `check-jsonschema`