### PR TITLE
add tool PNPM

### DIFF
--- a/tools/pnpm.json
+++ b/tools/pnpm.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "pnpm",
+    "publisher": "pnpm",
+    "description": "Fast, disk space efficient JavaScript package manager with a CLI command to generate SBOMs in CycloneDX and SPDX formats.",
+    "repository_url": "https://github.com/pnpm/pnpm",
+    "website_url": "https://pnpm.io/next/cli/sbom",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE"
+    ],
+    "functions": [
+      "PACKAGE_MANAGER_INTEGRATION"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.6"
+    ],
+    "supportedLanguages": [
+      "JAVASCRIPT/TYPESCRIPT",
+      "NODE.JS"
+    ]
+  }
+}


### PR DESCRIPTION
Adds `tools/pnpm.json` to register **pnpm** (a fast, disk-efficient JavaScript/TypeScript package manager) in Tool Center using schema v2.0. The entry highlights pnpm’s **native SBOM capability** via `pnpm sbom`, which generates BOMs directly from pnpm’s resolved dependency graph and supports major standards including **CycloneDX** and **SPDX**. Capability is classified as **SBOM** with function **PACKAGE_MANAGER_INTEGRATION** (deliberately not `AUTHOR`) to reflect that SBOM generation is integrated into package manager workflows rather than positioned as a manual, standalone BOM authoring tool.