### PR TITLE
Update BomLens URLs to renamed repository (sktelecom/bomlens)

### DIFF
--- a/tools/bomlens.json
+++ b/tools/bomlens.json
@@ -5,8 +5,8 @@
         "name": "BomLens",
         "publisher": "SK Telecom",
         "description": "Generates CycloneDX SBOMs from source code, containers, binaries, firmware, and HuggingFace AI models. Ingests existing CycloneDX/SPDX SBOMs and produces license and security findings and NOTICE files. CLI, web UI, and desktop app.",
-        "repository_url": "https://github.com/sktelecom/sbom-tools",
-        "website_url": "https://sktelecom.github.io/sbom-tools/",
+        "repository_url": "https://github.com/sktelecom/bomlens",
+        "website_url": "https://sktelecom.github.io/bomlens/",
         "capabilities": [
             "AI/ML-BOM",
             "SBOM"


### PR DESCRIPTION
The BomLens repository was renamed from `sktelecom/sbom-tools` to `sktelecom/bomlens`. This updates `repository_url` and `website_url` in `tools/bomlens.json` to the new paths (the old URLs currently 301-redirect, but the direct links are clearer).