### PR TITLE
Add SBOM Lens

### DIFF
--- a/tools/sbom_lens.json
+++ b/tools/sbom_lens.json
@@ -4,7 +4,7 @@
   "tool": {
     "name": "SBOM Lens",
     "publisher": "EverBright IT",
-    "description": "A fast client-side viewer for CycloneDX and SPDX SBOMs that resolves multi-document cascades, including CycloneDX BOM-Link references, into one navigable tree. VEX overlay (OpenVEX, CSAF 2.0), release diffing and NTIA / BSI TR-03183 profile checks. Files never leave the machine.",
+    "description": "Client-side viewer for CycloneDX and SPDX SBOMs: resolves multi-document cascades into one tree, overlays VEX (OpenVEX, CSAF 2.0), diffs releases, checks NTIA / BSI TR-03183 profiles. Files never leave the machine.",
     "repository_url": "https://github.com/EverBright-IT/SBOM-Lens",
     "website_url": "https://sbom-lens.everbright-it.de/",
     "capabilities": ["SBOM", "VDR/VEX"],

--- a/tools/sbom_lens.json
+++ b/tools/sbom_lens.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "SBOM Lens",
+    "publisher": "EverBright IT",
+    "description": "A fast client-side viewer for CycloneDX and SPDX SBOMs that resolves multi-document cascades, including CycloneDX BOM-Link references, into one navigable tree. VEX overlay (OpenVEX, CSAF 2.0), release diffing and NTIA / BSI TR-03183 profile checks. Files never leave the machine.",
+    "repository_url": "https://github.com/EverBright-IT/SBOM-Lens",
+    "website_url": "https://sbom-lens.everbright-it.de/",
+    "capabilities": ["SBOM", "VDR/VEX"],
+    "availability": ["OPEN_SOURCE", "OSI_APPROVED"],
+    "functions": ["ANALYSIS"],
+    "analysis": ["POLICY_EVALUATION", "LICENSE_REPORTING"],
+    "packaging": ["CONTAINER_IMAGE", "APPLICATION"],
+    "platform": ["LINUX", "MAC", "WINDOWS"],
+    "lifecycle": ["POST-BUILD", "OPERATIONS"],
+    "supportedStandards": ["CYCLONEDX", "SPDX", "PACKAGE_URL", "CPE"],
+    "cycloneDxVersion": ["CYCLONEDX_V1.4", "CYCLONEDX_V1.5", "CYCLONEDX_V1.6"]
+  }
+}


### PR DESCRIPTION
Adds tools/sbom_lens.json for SBOM Lens, a client-side viewer for CycloneDX and SPDX SBOMs (Apache-2.0). It resolves multi-document cascades into one navigable tree, including CycloneDX BOM-Link references (urn:cdx:<serial>/<version>#<bom-ref>) across documents. OpenVEX and CSAF 2.0 statements overlay the inventory via purl and CPE matching, releases can be diffed, and documents are checked against NTIA and BSI TR-03183 profiles. CycloneDX JSON ingestion is version-tolerant across 1.4-1.6. Entry validates against the tool-center-v2 schema.

Disclosure: I am the maintainer of the tool.