### PR TITLE
Add CBOM Compliance

### DIFF
--- a/tools/cbomcompliance.json
+++ b/tools/cbomcompliance.json
@@ -1,0 +1,43 @@
+{
+  "name": "NextGenRails CBOM Compliance",
+  "publisher": "NextGenRails",
+  "description": "Assesses cryptographic assets declared in a CycloneDX or SPDX manifest against NIST IR 8547 and the EO 14412 deadlines, then issues an offline-verifiable receipt dual-signed RS256 + ML-DSA-65 (FIPS 204). Free, uncapped check; nothing retained.",
+  "website_url": "https://cbomcompliance.com",
+  "capabilities": [
+    "CBOM",
+    "SBOM"
+  ],
+  "availability": [
+    "FREEMIUM",
+    "SUBSCRIPTION"
+  ],
+  "functions": [
+    "ANALYSIS",
+    "SIGNING/NOTARY"
+  ],
+  "analysis": [
+    "POLICY_EVALUATION",
+    "SECURITY_VULNERABILITIES"
+  ],
+  "packaging": [
+    "APPLICATION"
+  ],
+  "platform": [
+    "LINUX",
+    "MAC",
+    "WINDOWS"
+  ],
+  "lifecycle": [
+    "POST-BUILD",
+    "OPERATIONS"
+  ],
+  "supportedStandards": [
+    "CYCLONEDX",
+    "SPDX"
+  ],
+  "cycloneDxVersion": [
+    "CYCLONEDX_V1.7",
+    "CYCLONEDX_V1.6",
+    "CYCLONEDX_V1.5"
+  ]
+}

--- a/tools/cbomcompliance.json
+++ b/tools/cbomcompliance.json
@@ -1,43 +1,18 @@
 {
-  "name": "NextGenRails CBOM Compliance",
-  "publisher": "NextGenRails",
-  "description": "Assesses cryptographic assets declared in a CycloneDX or SPDX manifest against NIST IR 8547 and the EO 14412 deadlines, then issues an offline-verifiable receipt dual-signed RS256 + ML-DSA-65 (FIPS 204). Free, uncapped check; nothing retained.",
-  "website_url": "https://cbomcompliance.com",
-  "capabilities": [
-    "CBOM",
-    "SBOM"
-  ],
-  "availability": [
-    "FREEMIUM",
-    "SUBSCRIPTION"
-  ],
-  "functions": [
-    "ANALYSIS",
-    "SIGNING/NOTARY"
-  ],
-  "analysis": [
-    "POLICY_EVALUATION",
-    "SECURITY_VULNERABILITIES"
-  ],
-  "packaging": [
-    "APPLICATION"
-  ],
-  "platform": [
-    "LINUX",
-    "MAC",
-    "WINDOWS"
-  ],
-  "lifecycle": [
-    "POST-BUILD",
-    "OPERATIONS"
-  ],
-  "supportedStandards": [
-    "CYCLONEDX",
-    "SPDX"
-  ],
-  "cycloneDxVersion": [
-    "CYCLONEDX_V1.7",
-    "CYCLONEDX_V1.6",
-    "CYCLONEDX_V1.5"
-  ]
+  "specVersion": "2.0",
+  "tool": {
+    "name": "NextGenRails CBOM Compliance",
+    "publisher": "NextGenRails",
+    "description": "Assesses cryptographic assets declared in a CycloneDX or SPDX manifest against NIST IR 8547 and the EO 14412 deadlines, then issues an offline-verifiable receipt dual-signed RS256 + ML-DSA-65 (FIPS 204). Free, uncapped check; nothing retained.",
+    "website_url": "https://cbomcompliance.com",
+    "capabilities": ["CBOM", "SBOM"],
+    "availability": ["FREEMIUM", "SUBSCRIPTION"],
+    "functions": ["ANALYSIS", "SIGNING/NOTARY"],
+    "analysis": ["POLICY_EVALUATION", "SECURITY_VULNERABILITIES"],
+    "packaging": ["APPLICATION"],
+    "platform": ["LINUX", "MAC", "WINDOWS"],
+    "lifecycle": ["POST-BUILD", "OPERATIONS"],
+    "supportedStandards": ["CYCLONEDX", "SPDX"],
+    "cycloneDxVersion": ["CYCLONEDX_V1.7", "CYCLONEDX_V1.6", "CYCLONEDX_V1.5"]
+  }
 }


### PR DESCRIPTION
Adds NextGenRails CBOM Compliance to the tool center.

It reads the cryptographic assets declared in a CycloneDX or SPDX manifest, grades each against NIST IR 8547 and the applicable EO 14412 deadlines, and can issue an offline-verifiable receipt over the manifest — a JWS dual-signed with RS256 and ML-DSA-65 (FIPS 204), checkable against a published keyset without contacting the service. The free assessment is uncapped and nothing is retained.

New file added at tools/cbomcompliance.json; tools.json left untouched. Validated against schemas/tool.schema.json. Happy to adjust the categorization or any field if you'd like it classified differently.