### PR TITLE
feat: add CVD Portal SBOM Validator

### DIFF
--- a/tools/cvd_portal_sbom_validator.json
+++ b/tools/cvd_portal_sbom_validator.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CVD Portal SBOM Validator",
+    "publisher": "Porta Regulus B.V.",
+    "description": "Free hosted validator that checks a CycloneDX or SPDX document against BSI TR-03183-2 and reports pass or fail for each requirement with its clause reference, including the specification version minimum. No signup.",
+    "website_url": "https://cvdportal.com/tools/sbom-validator",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "analysis": [
+      "POLICY_EVALUATION"
+    ],
+    "transform": [],
+    "packaging": [],
+    "library": [],
+    "platform": [],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "SPDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.2",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.7"
+    ],
+    "supportedLanguages": []
+  }
+}


### PR DESCRIPTION
Adds one file under `tools/` for a free SBOM conformance checker. `tools.json` is untouched, since the README says it is assembled from that folder.

### The tool

A hosted validator at https://cvdportal.com/tools/sbom-validator. It parses an uploaded CycloneDX or SPDX document and reports conformance against BSI TR-03183-2 v2.1.0, per requirement with the clause reference rather than as a single score, and separately reports whether the document meets that guideline's minimum specification version. The same check is available unauthenticated at `POST /api/tools/sbom-validate`, so it runs in CI without an install. No signup, rate limited to 10 per hour per IP, nothing stored and contents never logged.

`SBOM Lens` already covers TR-03183 profile checking in this listing and does it well. This is a different shape rather than a replacement: hosted and callable from CI rather than client-side.

### How the entry was checked

- Validates against `schemas/tool.schema.json` with a Draft 2020-12 validator. Description is 214 characters against the 250 limit.
- No existing CVD Portal or Porta Regulus entry among the 302 current tools, and no name clash.
- Every declared value was taken from a live call to the endpoint, not assumed. CycloneDX 1.5 and SPDX 2.0, 2.1, 2.2, 2.3 and 3.0.1 documents were each posted and the detected format, version and component count confirmed.

### Two deliberate choices, happy to change either

`packaging`, `platform` and `library` are empty. It is a hosted service and the enums have no value for that, so `APPLICATION` would have implied something installable.

`cycloneDxVersion` starts at 1.2 because that is where CycloneDX JSON starts. The parser reads whatever `specVersion` a document declares rather than allow-listing versions, so the range reflects what it will read rather than a tested matrix beyond the versions listed above.

`availability` is `FREEMIUM`: the validator is free and unauthenticated, the platform behind it is not open source.