### PR TITLE
Add CBOM-Lens and CBOM-Repository to Tool Center

### DIFF
--- a/tools/cbom_lens.json
+++ b/tools/cbom_lens.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CBOM-Lens",
+    "publisher": "OmniTrust",
+    "description": "Discovers certificates, keys, secrets, and algorithms on local systems, in container images, and on network services, generating a CycloneDX 1.6 or 1.7 CBOM. Detects post-quantum algorithms and emits the 1.7 algorithmFamily and ellipticCurve fields.",
+    "repository_url": "https://github.com/OmniTrustILM/cbom-lens",
+    "website_url": "https://omnitrust.com",
+    "capabilities": [
+      "CBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS"
+    ],
+    "packaging": [
+      "COMMAND_LINE_UTILITY",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS",
+      "DISCOVERY"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.7",
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}

--- a/tools/cbom_repository.json
+++ b/tools/cbom_repository.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CBOM-Repository",
+    "publisher": "OmniTrust",
+    "description": "REST API service for storing, versioning, retrieving, and searching CycloneDX CBOM documents on S3-compatible object storage. Assigns serial numbers and versions when missing. Deployed as a container image or Helm chart.",
+    "repository_url": "https://github.com/OmniTrustILM/cbom-repository",
+    "website_url": "https://omnitrust.com",
+    "capabilities": [
+      "CBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "CONTAINER_IMAGE"
+    ],
+    "library": [
+      "GO"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "POST-BUILD",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.7",
+      "CYCLONEDX_V1.6"
+    ]
+  }
+}


### PR DESCRIPTION
Adds two CBOM tools to the Tool Center.

**CBOM-Lens** — CLI that discovers certificates, keys, secrets, and algorithms on local systems, in container images, and on network services, and generates a CycloneDX 1.6 or 1.7 CBOM. Detects post-quantum algorithms and emits the CycloneDX 1.7 `algorithmFamily` and `ellipticCurve` registry fields.

**CBOM-Repository** — REST API service that stores, versions, retrieves, and searches CycloneDX CBOM documents on S3-compatible object storage.

Both are MIT-licensed and published by OmniTrust. Only files in `tools/` are added; `tools.json` is left to the assembly workflow.
