### PR TITLE
Add CRA Release Evidence

### DIFF
--- a/tools/cra_release_evidence.json
+++ b/tools/cra_release_evidence.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "CRA Release Evidence",
+    "publisher": "Warnowdigitalsolutions",
+    "description": "GitHub Action that imports CycloneDX SBOMs and packages them with existing test, security, and Git data into versioned Markdown and JSON release evidence. It does not scan or make compliance decisions.",
+    "repository_url": "https://github.com/mastermuetze/cra-release-evidence",
+    "website_url": "https://github.com/marketplace/actions/cra-release-evidence",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "DISTRIBUTE"
+    ],
+    "packaging": [
+      "GITHUB_ACTION"
+    ],
+    "library": [
+      "JAVASCRIPT_TYPESCRIPT"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "POST-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.7",
+      "CYCLONEDX_V1.6",
+      "CYCLONEDX_V1.5",
+      "CYCLONEDX_V1.4",
+      "CYCLONEDX_V1.3",
+      "CYCLONEDX_V1.2"
+    ]
+  }
+}


### PR DESCRIPTION
## What changed

Adds a Tool Center v2 entry for CRA Release Evidence, an MIT-licensed GitHub Action that imports CycloneDX 1.2–1.7 JSON SBOMs and retains them in version-specific Markdown and JSON release evidence packages.

## Scope

The metadata deliberately claims only the `DISTRIBUTE` function. The Action performs limited structural recognition; it is not a scanner, full CycloneDX schema validator, vulnerability analysis tool, or compliance/legal verdict.

Source: https://github.com/mastermuetze/cra-release-evidence

## Validation

- `check-jsonschema --schemafile schemas/tool.schema.json tools/cra_release_evidence.json`
- assembled `tools.json` with `helpers/tools-assemble.py`
- `check-jsonschema --schemafile schemas/tools.schema.json tools.json`
- `git diff --check`
