### PR TITLE
Add ClaveQ Scan

### DIFF
--- a/tools/claveq_scan.json
+++ b/tools/claveq_scan.json
@@ -6,7 +6,6 @@
     "publisher": "ClaveQ",
     "description": "Passive cryptographic discovery for OT and critical infrastructure networks — classifies quantum-vulnerable vs quantum-safe crypto in use, zero packets stored, no agents, and outputs a schema-validated CycloneDX 1.7 CBOM as evidence.",
     "website_url": "https://www.claveq.com",
-    "repository_url": "https://github.com/ClaveQuantum/claveq-cyclonedx",
     "capabilities": [
       "CBOM"
     ],
@@ -14,8 +13,7 @@
       "FREEMIUM"
     ],
     "functions": [
-      "ANALYSIS",
-      "AUTHOR"
+      "ANALYSIS"
     ],
     "analysis": [
       "SECURITY_VULNERABILITIES"

--- a/tools/claveq_scan.json
+++ b/tools/claveq_scan.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "ClaveQ Scan",
+    "publisher": "ClaveQ",
+    "description": "Passive cryptographic discovery for OT and critical infrastructure networks — classifies quantum-vulnerable vs quantum-safe crypto in use, zero packets stored, no agents, and outputs a schema-validated CycloneDX 1.7 CBOM as evidence.",
+    "website_url": "https://www.claveq.com",
+    "repository_url": "https://github.com/ClaveQuantum/claveq-cyclonedx",
+    "capabilities": [
+      "CBOM"
+    ],
+    "availability": [
+      "FREEMIUM"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES"
+    ],
+    "packaging": [
+      "APPLICATION",
+      "COMMAND_LINE_UTILITY"
+    ],
+    "platform": [
+      "LINUX"
+    ],
+    "lifecycle": [
+      "DISCOVERY",
+      "OPERATIONS"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.7"
+    ]
+  }
+}


### PR DESCRIPTION
Adds a Tool Center entry for ClaveQ Scan — passive cryptographic discovery for OT and critical-infrastructure networks. It classifies quantum-vulnerable, quantum-safe, broken-classical, and unencrypted crypto in use across a network (via a SPAN/mirror port, zero packets transmitted, no agents) and outputs a schema-validated CycloneDX 1.7 Cryptography Bill of Materials.

`tools/claveq_scan.json` validates against `schemas/tool.schema.json` with `check-jsonschema`.

Repository link points to https://github.com/ClaveQuantum/claveq-cyclonedx, a small companion repo of example CBOM output (Apache-2.0) — the product itself is closed-source.