### PR TITLE
Add Celmis

### DIFF
--- a/tools/celmis.json
+++ b/tools/celmis.json
@@ -4,7 +4,7 @@
   "tool": {
     "name": "Celmis",
     "publisher": "Celmis Labs",
-    "description": "Self-hosted code intelligence that indexes repositories into a symbol graph and audits their dependencies deterministically — each ecosystem's native auditor, with lock files and OSV.dev elsewhere. Exports a CycloneDX 1.5 SBOM with package URLs, plus an evidence pack whose manifest of sha256 digests lets a third party verify it without trusting the machine that produced it. Reports the ecosystems it could not fully resolve alongside the findings.",
+    "description": "Self-hosted code intelligence that indexes repositories into a symbol graph and audits their dependencies deterministically — each ecosystem's native auditor, with lock files and OSV.dev elsewhere. Exports a CycloneDX 1.5 SBOM with package URLs, plus an evidence pack whose manifest of sha256 digests a third party can recompute offline with a dependency-free verifier. Those digests prove the archive is internally consistent; the manifest carries no digest of itself, so the export returns the manifest's own sha256 in a header to be published separately, and only that makes the check independent of the machine that produced the pack. Reports the ecosystems it could not fully resolve alongside the findings.",
     "repository_url": "https://github.com/Celmis-labs/Celmis",
     "website_url": "https://celmis-labs.github.io",
     "capabilities": [
@@ -16,7 +16,7 @@
     ],
     "functions": [
       "ANALYSIS",
-      "AUTHOR"
+      "PACKAGE_MANAGER_INTEGRATION"
     ],
     "analysis": [
       "SECURITY_VULNERABILITIES",
@@ -43,11 +43,11 @@
       "CYCLONEDX_V1.5"
     ],
     "supportedLanguages": [
-      "PYTHON",
+      "GO",
       "JAVASCRIPT/TYPESCRIPT",
-      "JAVA",
-      ".NET",
       "PHP",
+      "PYTHON",
+      "RUBY",
       "RUST"
     ]
   }

--- a/tools/celmis.json
+++ b/tools/celmis.json
@@ -4,7 +4,7 @@
   "tool": {
     "name": "Celmis",
     "publisher": "Celmis Labs",
-    "description": "Self-hosted code intelligence that indexes repositories into a symbol graph and audits their dependencies deterministically — each ecosystem's native auditor, with lock files and OSV.dev elsewhere. Exports a CycloneDX 1.5 SBOM with package URLs, plus an evidence pack whose manifest of sha256 digests a third party can recompute offline with a dependency-free verifier. Those digests prove the archive is internally consistent; the manifest carries no digest of itself, so the export returns the manifest's own sha256 in a header to be published separately, and only that makes the check independent of the machine that produced the pack. Reports the ecosystems it could not fully resolve alongside the findings.",
+    "description": "Self-hosted code intelligence. Indexes repositories into a symbol graph and audits dependencies deterministically — each ecosystem's native auditor, OSV-Scanner for the rest. Exports a CycloneDX 1.5 SBOM and an evidence pack of sha256 digests.",
     "repository_url": "https://github.com/Celmis-labs/Celmis",
     "website_url": "https://celmis-labs.github.io",
     "capabilities": [
@@ -43,7 +43,9 @@
       "CYCLONEDX_V1.5"
     ],
     "supportedLanguages": [
+      ".NET",
       "GO",
+      "JAVA",
       "JAVASCRIPT/TYPESCRIPT",
       "PHP",
       "PYTHON",

--- a/tools/celmis.json
+++ b/tools/celmis.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "Celmis",
+    "publisher": "Celmis Labs",
+    "description": "Self-hosted code intelligence that indexes repositories into a symbol graph and audits their dependencies deterministically — each ecosystem's native auditor, with lock files and OSV.dev elsewhere. Exports a CycloneDX 1.5 SBOM with package URLs, plus an evidence pack whose manifest of sha256 digests lets a third party verify it without trusting the machine that produced it. Reports the ecosystems it could not fully resolve alongside the findings.",
+    "repository_url": "https://github.com/Celmis-labs/Celmis",
+    "website_url": "https://celmis-labs.github.io",
+    "capabilities": [
+      "SBOM"
+    ],
+    "availability": [
+      "OPEN_SOURCE",
+      "OSI_APPROVED"
+    ],
+    "functions": [
+      "ANALYSIS",
+      "AUTHOR"
+    ],
+    "analysis": [
+      "SECURITY_VULNERABILITIES",
+      "OUTDATED_COMPONENTS",
+      "RESOURCE_REPORTING"
+    ],
+    "packaging": [
+      "CONTAINER_IMAGE",
+      "APPLICATION"
+    ],
+    "platform": [
+      "LINUX",
+      "MAC",
+      "WINDOWS"
+    ],
+    "lifecycle": [
+      "PRE-BUILD"
+    ],
+    "supportedStandards": [
+      "CYCLONEDX",
+      "PACKAGE_URL"
+    ],
+    "cycloneDxVersion": [
+      "CYCLONEDX_V1.5"
+    ],
+    "supportedLanguages": [
+      "PYTHON",
+      "JAVASCRIPT/TYPESCRIPT",
+      "JAVA",
+      ".NET",
+      "PHP",
+      "RUST"
+    ]
+  }
+}


### PR DESCRIPTION
Adds `tools/celmis.json`.

**Celmis** is self-hosted code intelligence. Relevant to this catalogue: it audits a workspace's dependencies deterministically — each ecosystem's native auditor where it is installed, lock files plus OSV.dev elsewhere, no language model in that path — and exports a CycloneDX 1.5 SBOM with package URLs.

Alongside the SBOM it produces an evidence pack: the SBOM, the findings, an append-only timeline, and a `MANIFEST.json` of sha256 digests over all of them, so a recipient can verify the pack without trusting the machine that produced it.

Two things stated deliberately:

- `LICENSE_REPORTING` is **not** claimed. The audit reports vulnerabilities, outdated components and an inventory; it does not do licence analysis, and I would rather leave the capability off than have someone find it missing.
- The audit reports the ecosystems it could **not** fully resolve alongside the findings, because an unchecked ecosystem reports zero vulnerabilities exactly like a clean one.

`tools.json` is untouched — I understand it is generated from `tools/`. Validated against `tool-center-v2.tool.schema.json`; every enum value is drawn from the schema.

Disclosure: I maintain the project.
