### PR TITLE
Add cbomctl (CBOM policy evaluation)

### DIFF
--- a/tools/cbomctl.json
+++ b/tools/cbomctl.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://cyclonedx.org/schema/tool-center-v2.tool.schema.json",
+  "specVersion": "2.0",
+  "tool": {
+    "name": "cbomctl",
+    "publisher": "Sadjad Asadi",
+    "description": "Evaluates a CycloneDX CBOM against seven national post-quantum policies at once (BSI, ANSSI, ASD, CNSA 2.0, EO 14412, EU roadmap, NIST IR 8547) and reports where their verdicts contradict. Every rule cites a primary source and a verification date.",
+    "repository_url": "https://github.com/lvlrSajjad/cbomctl",
+    "website_url": "https://lvlrsajjad.github.io/cbomctl/",
+    "capabilities": ["CBOM"],
+    "availability": ["OPEN_SOURCE", "OSI_APPROVED"],
+    "functions": ["ANALYSIS"],
+    "analysis": ["POLICY_EVALUATION"],
+    "transform": [],
+    "packaging": ["COMMAND_LINE_UTILITY", "GITHUB_ACTION"],
+    "library": ["PYTHON"],
+    "platform": ["LINUX", "MAC", "WINDOWS"],
+    "lifecycle": ["POST-BUILD", "OPERATIONS"],
+    "supportedStandards": ["CYCLONEDX"],
+    "cycloneDxVersion": ["CYCLONEDX_V1.7", "CYCLONEDX_V1.6"],
+    "supportedLanguages": []
+  }
+}


### PR DESCRIPTION

Adds `cbomctl`, an open-source (Apache-2.0) CLI that consumes a CycloneDX 1.6 /
1.7 CBOM and evaluates it against several national post-quantum cryptography
policies simultaneously, reporting a per-asset × jurisdiction verdict matrix
plus the conflicts between them.

The gap it fills: national PQC guidance has diverged in ways that matter for
anyone shipping into more than one market. BSI and ANSSI recommend hybrid key
establishment; ASD's ISM recommends against it; CNSA 2.0 asks for ML-KEM-1024
where others accept ML-KEM-768. Tools generally evaluate one framework at a time
and report PASS/FAIL, which hides the contradiction. `cbomctl` computes it and
names a satisfies-all target where one exists.

Two things I'd flag rather than have a reviewer discover:

- **It consumes CBOMs, it does not generate them.** It complements the
  generators already in the Tool Center rather than competing with them.
  `capabilities: ["CBOM"]` and `analysis: ["POLICY_EVALUATION"]` are chosen to
  reflect that; happy to change either if the maintainers read the taxonomy
  differently.
- **The policy rules are versioned separately from the tool** and are
  consumable without it, with a primary-source URL, a verification date and a
  binding classification (statute / executive order / agency requirement /
  certification requirement / guideline recommendation) on every rule. The
  binding field exists because most PQC guidance is *not* a mandate, and
  reporting a technical guideline as a legal requirement is a common failure
  mode.

The JSON validates against `schemas/tool.schema.json` (specVersion 2.0). Happy
to adjust any field.
